### PR TITLE
feat: add client CRUD and remove duplicated types

### DIFF
--- a/components/ClientCard.tsx
+++ b/components/ClientCard.tsx
@@ -5,24 +5,29 @@ export default function ClientCard({
   client,
   onEdit,
   onDelete,
+  children,
 }: {
   client: Client;
   onEdit: (c: Client) => void;
   onDelete: (id: string) => void;
+  children?: React.ReactNode;
 }) {
   const name = `${client.first_name}${client.last_name ? ' ' + client.last_name : ''}`;
   return (
-    <div className="border rounded-2xl p-4 flex items-center justify-between">
-      <div>
-        <div className="font-semibold">{name}</div>
-        <div className="text-sm text-gray-600">
-          {client.phone || '—'} • {client.district || '—'} • статус: {client.payment_status || '—'}
+    <div className="border rounded-2xl p-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="font-semibold">{name}</div>
+          <div className="text-sm text-gray-600">
+            {client.phone || '—'} • {client.district || '—'} • статус: {client.payment_status || '—'}
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <button className="px-3 py-1 rounded bg-blue-600 text-white" onClick={() => onEdit(client)}>Edit</button>
+          <button className="px-3 py-1 rounded bg-red-600 text-white" onClick={() => onDelete(client.id)}>Delete</button>
         </div>
       </div>
-      <div className="flex gap-2">
-        <button className="px-3 py-1 rounded bg-blue-600 text-white" onClick={() => onEdit(client)}>Edit</button>
-        <button className="px-3 py-1 rounded bg-red-600 text-white" onClick={() => onDelete(client.id)}>Delete</button>
-      </div>
+      {children && <div className="mt-3">{children}</div>}
     </div>
   );
 }

--- a/pages/clients.tsx
+++ b/pages/clients.tsx
@@ -1,63 +1,69 @@
 import { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
+import { Client } from '../lib/types';
+import ClientCard from '../components/ClientCard';
 import ClientGroupPicker from '../components/ClientGroupPicker';
-
-type Client = {
-  id: string;
-  first_name: string;
-  last_name: string | null;
-  district: string | null;
-  payment_status: string | null;
-};
+import ClientModal from '../components/ClientModal';
 
 export default function ClientsPage() {
   const [clients, setClients] = useState<Client[]>([]);
   const [loading, setLoading] = useState(true);
+  const [openModal, setOpenModal] = useState(false);
+  const [editing, setEditing] = useState<Client | null>(null);
 
-  useEffect(() => {
-    let ignore = false;
-    (async () => {
-      const { data, error } = await supabase
-        .from('clients')
-        .select('id, first_name, last_name, district, payment_status')
-        .order('created_at', { ascending: false });
-      if (!ignore) {
-        if (error) console.error(error);
-        setClients(data || []);
-        setLoading(false);
-      }
-    })();
-    return () => { ignore = true; };
-  }, []);
+  async function loadData() {
+    setLoading(true);
+    const { data, error } = await supabase
+      .from('clients')
+      .select('id, first_name, last_name, phone, district, payment_status')
+      .order('created_at', { ascending: false });
+    if (!error && data) setClients(data as Client[]);
+    setLoading(false);
+  }
+
+  useEffect(() => { loadData(); }, []);
+
+  const openAdd = () => { setEditing(null); setOpenModal(true); };
+  const openEdit = (c: Client) => { setEditing(c); setOpenModal(true); };
+
+  const remove = async (id: string) => {
+    if (!confirm('Delete client?')) return;
+    const { error } = await supabase.from('clients').delete().eq('id', id);
+    if (error) alert(error.message); else loadData();
+  };
 
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Clients</h1>
+      <div className="mb-4">
+        <button
+          onClick={openAdd}
+          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+        >
+          + Add Client
+        </button>
+      </div>
       {loading && <div className="text-gray-500">loading…</div>}
       <div className="space-y-3">
         {clients.map((c) => (
-          <div key={c.id} className="rounded-2xl border bg-white p-4">
-            <div className="flex items-center justify-between">
-              <div>
-                <div className="font-semibold">
-                  {c.first_name} {c.last_name || ''}
-                </div>
-                <div className="text-sm text-gray-500">
-                  {c.district || '—'} • {c.payment_status || '—'}
-                </div>
-              </div>
-            </div>
-
-            <div className="mt-3">
+          <ClientCard key={c.id} client={c} onEdit={openEdit} onDelete={remove}>
+            <div>
               <div className="text-xs uppercase text-gray-400 mb-1">Groups</div>
               <ClientGroupPicker clientId={c.id} />
             </div>
-          </div>
+          </ClientCard>
         ))}
         {!loading && clients.length === 0 && (
           <div className="text-gray-500">no clients yet</div>
         )}
       </div>
+      {openModal && (
+        <ClientModal
+          initial={editing}
+          onClose={() => setOpenModal(false)}
+          onSaved={() => { setOpenModal(false); loadData(); }}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add full CRUD workflow for clients
- reuse Client type and ClientCard to remove duplication
- allow extra content within ClientCard

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c02ebc28d4832b9781cbfba9b54073