### PR TITLE
feat: add basic leads pipeline

### DIFF
--- a/components/LeadCard.tsx
+++ b/components/LeadCard.tsx
@@ -1,0 +1,13 @@
+import type { Lead } from '../lib/types';
+
+export default function LeadCard({ lead }: { lead: Lead }) {
+  return (
+    <div className="bg-white rounded shadow p-2 mb-2">
+      <div className="font-medium">{lead.name}</div>
+      {lead.phone && (
+        <div className="text-sm text-gray-500">{lead.phone}</div>
+      )}
+      <div className="text-xs text-gray-400 mt-1">{lead.source}</div>
+    </div>
+  );
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -13,3 +13,12 @@ export type Client = {
   payment_method: 'cash' | 'transfer' | null;
   district: string | null;
 };
+
+export type Lead = {
+  id: string;
+  created_at: string;
+  name: string;
+  phone: string | null;
+  source: 'instagram' | 'whatsapp' | 'telegram';
+  stage: 'queue' | 'hold' | 'trial' | 'awaiting_payment' | 'paid' | 'canceled';
+};

--- a/pages/leads.tsx
+++ b/pages/leads.tsx
@@ -1,8 +1,47 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabaseClient';
+import type { Lead } from '../lib/types';
+import LeadCard from '../components/LeadCard';
+
+const STAGES = [
+  { key: 'queue', title: 'Очередь' },
+  { key: 'hold', title: 'Задержка' },
+  { key: 'trial', title: 'Пробное' },
+  { key: 'awaiting_payment', title: 'Ожидание оплаты' },
+  { key: 'paid', title: 'Оплачено' },
+  { key: 'canceled', title: 'Отмена' },
+] as const;
+
 export default function LeadsPage() {
+  const [leads, setLeads] = useState<Lead[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  async function loadData() {
+    setLoading(true);
+    const { data, error } = await supabase
+      .from('leads')
+      .select('id, created_at, name, phone, source, stage')
+      .order('created_at', { ascending: false });
+    if (!error && data) setLeads(data as Lead[]);
+    setLoading(false);
+  }
+
+  useEffect(() => { loadData(); }, []);
+
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Leads</h1>
-      <p className="text-gray-600">Тут сделаем воронку (Queue → Trial → Awaiting payment → Paid), и конвертацию в клиента.</p>
+      {loading && <div className="text-gray-500">loading…</div>}
+      <div className="flex gap-4 overflow-x-auto">
+        {STAGES.map((stage) => (
+          <div key={stage.key} className="w-64 shrink-0">
+            <h2 className="text-center font-semibold mb-2">{stage.title}</h2>
+            {leads.filter((l) => l.stage === stage.key).map((l) => (
+              <LeadCard key={l.id} lead={l} />
+            ))}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add Lead type and simple card component
- implement leads page showing stages of pipeline

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0862e6be0832bbe8b584ff59008bc