### PR TITLE
feat: add basic leads pipeline

### DIFF
--- a/components/LeadCard.tsx
+++ b/components/LeadCard.tsx
@@ -1,0 +1,31 @@
+import type { Lead, LeadStage } from '../lib/types';
+import { LEAD_STAGES } from '../lib/types';
+
+export default function LeadCard({
+  lead,
+  onStageChange,
+}: {
+  lead: Lead;
+  onStageChange: (id: string, stage: LeadStage) => void;
+}) {
+  return (
+    <div className="bg-white rounded shadow p-2 mb-2">
+      <div className="font-medium">{lead.name}</div>
+      {lead.phone && (
+        <div className="text-sm text-gray-500">{lead.phone}</div>
+      )}
+      <select
+        className="mt-2 w-full border rounded text-sm"
+        value={lead.stage}
+        onChange={(e) => onStageChange(lead.id, e.target.value as LeadStage)}
+      >
+        {LEAD_STAGES.map((s) => (
+          <option key={s.key} value={s.key}>
+            {s.title}
+          </option>
+        ))}
+      </select>
+      <div className="text-xs text-gray-400 mt-1">{lead.source}</div>
+    </div>
+  );
+}

--- a/components/LeadForm.tsx
+++ b/components/LeadForm.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import { LEAD_SOURCES } from '../lib/types';
+import type { LeadSource } from '../lib/types';
+
+export default function LeadForm({
+  onAdd,
+}: {
+  onAdd: (data: { name: string; phone: string | null; source: LeadSource }) => Promise<void>;
+}) {
+  const [name, setName] = useState('');
+  const [phone, setPhone] = useState('');
+  const [source, setSource] = useState<LeadSource>('instagram');
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    await onAdd({ name, phone: phone || null, source });
+    setName('');
+    setPhone('');
+    setSource('instagram');
+  }
+
+  return (
+    <form onSubmit={submit} className="flex gap-2 mb-4 flex-wrap">
+      <input
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Имя"
+        className="border p-1 flex-1 min-w-[8rem]"
+        required
+      />
+      <input
+        value={phone}
+        onChange={(e) => setPhone(e.target.value)}
+        placeholder="Телефон"
+        className="border p-1 flex-1 min-w-[8rem]"
+      />
+      <select
+        value={source}
+        onChange={(e) => setSource(e.target.value as LeadSource)}
+        className="border p-1"
+      >
+        {LEAD_SOURCES.map((s) => (
+          <option key={s} value={s}>
+            {s}
+          </option>
+        ))}
+      </select>
+      <button
+        type="submit"
+        className="bg-blue-500 text-white px-3 py-1 rounded"
+      >
+        Добавить
+      </button>
+    </form>
+  );
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -13,3 +13,25 @@ export type Client = {
   payment_method: 'cash' | 'transfer' | null;
   district: string | null;
 };
+
+export const LEAD_SOURCES = ['instagram', 'whatsapp', 'telegram'] as const;
+export type LeadSource = typeof LEAD_SOURCES[number];
+
+export const LEAD_STAGES = [
+  { key: 'queue', title: 'Очередь' },
+  { key: 'hold', title: 'Задержка' },
+  { key: 'trial', title: 'Пробное' },
+  { key: 'awaiting_payment', title: 'Ожидание оплаты' },
+  { key: 'paid', title: 'Оплачено' },
+  { key: 'canceled', title: 'Отмена' },
+] as const;
+export type LeadStage = typeof LEAD_STAGES[number]['key'];
+
+export type Lead = {
+  id: string;
+  created_at: string;
+  name: string;
+  phone: string | null;
+  source: LeadSource;
+  stage: LeadStage;
+};


### PR DESCRIPTION
## Summary
- centralize lead stage and source constants
- add lead creation form and stage update controls
- allow moving leads between pipeline stages

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0862e6be0832bbe8b584ff59008bc