### PR TITLE
Clarify client date fields and add district dropdown

### DIFF
--- a/components/ClientModal.tsx
+++ b/components/ClientModal.tsx
@@ -63,10 +63,28 @@ export default function ClientModal({
             <option value="telegram">Telegram</option>
             <option value="instagram">Instagram</option>
           </select>
-          <input type="date" className="border rounded p-2 col-span-1" value={form.birth_date ?? ''} onChange={e => set('birth_date', e.target.value)} />
-          <input className="border rounded p-2 col-span-1" placeholder="Родитель"
-                 value={form.parent_name ?? ''} onChange={e => set('parent_name', e.target.value)} />
-          <input type="date" className="border rounded p-2 col-span-1" value={form.start_date ?? ''} onChange={e => set('start_date', e.target.value)} />
+          <input
+            type="date"
+            className="border rounded p-2 col-span-1"
+            placeholder="Дата рождения"
+            aria-label="Дата рождения"
+            value={form.birth_date ?? ''}
+            onChange={e => set('birth_date', e.target.value)}
+          />
+          <input
+            className="border rounded p-2 col-span-1"
+            placeholder="Родитель"
+            value={form.parent_name ?? ''}
+            onChange={e => set('parent_name', e.target.value)}
+          />
+          <input
+            type="date"
+            className="border rounded p-2 col-span-1"
+            placeholder="Начало посещения"
+            aria-label="Начало посещения"
+            value={form.start_date ?? ''}
+            onChange={e => set('start_date', e.target.value)}
+          />
           <select className="border rounded p-2 col-span-1" value={form.gender ?? ''} onChange={e => set('gender', e.target.value || null)}>
             <option value="">Пол</option>
             <option value="m">М</option>
@@ -83,8 +101,16 @@ export default function ClientModal({
             <option value="cash">Нал</option>
             <option value="transfer">Перевод</option>
           </select>
-          <input className="border rounded p-2 col-span-2" placeholder="Район"
-                 value={form.district ?? ''} onChange={e => set('district', e.target.value)} />
+          <select
+            className="border rounded p-2 col-span-2"
+            value={form.district ?? ''}
+            onChange={e => set('district', e.target.value || null)}
+          >
+            <option value="">Район</option>
+            <option value="Центр">Центр</option>
+            <option value="Джикджилли">Джикджилли</option>
+            <option value="Махмутлар">Махмутлар</option>
+          </select>
         </div>
         <div className="flex justify-end gap-2">
           <button className="px-3 py-2 rounded bg-gray-200" onClick={onClose}>Cancel</button>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -11,7 +11,7 @@ export type Client = {
   gender: 'm' | 'f' | null;
   payment_status: 'pending' | 'active' | 'debt' | null;
   payment_method: 'cash' | 'transfer' | null;
-  district: string | null;
+  district: 'Центр' | 'Джикджилли' | 'Махмутлар' | null;
 };
 
 export type Lead = {


### PR DESCRIPTION
## Summary
- Differentiate birth and start date fields in client modal
- Replace free-text district with dropdown of predefined options

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c09812845c832b92d5e1c60213b4ea