### PR TITLE
feat: manually add leads via modal

### DIFF
--- a/components/LeadModal.tsx
+++ b/components/LeadModal.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabaseClient';
+import type { Lead } from '../lib/types';
+import { LEAD_STAGES } from '../lib/leadStages';
+
+export default function LeadModal({
+  initial,
+  onClose,
+  onSaved,
+}: {
+  initial?: Lead | null;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [form, setForm] = useState<Partial<Lead>>({});
+
+  useEffect(() => { setForm(initial ?? {}); }, [initial]);
+
+  const set = (k: keyof Lead, v: Lead[keyof Lead]) =>
+    setForm((s) => ({ ...s, [k]: v }));
+
+  const save = async () => {
+    if (!form.name) { alert('Введите имя'); return; }
+    if (!form.source) { alert('Выберите источник'); return; }
+    const payload = {
+      name: form.name,
+      phone: form.phone ?? null,
+      source: form.source,
+      stage: (form.stage as Lead['stage']) ?? 'queue',
+    };
+    let error;
+    if (initial?.id) {
+      ({ error } = await supabase.from('leads').update(payload).eq('id', initial.id));
+    } else {
+      ({ error } = await supabase.from('leads').insert(payload));
+    }
+    if (error) { alert(error.message); return; }
+    onSaved();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/30 flex items-center justify-center p-4">
+      <div className="bg-white rounded-2xl p-4 w-full max-w-lg space-y-3">
+        <div className="text-lg font-semibold">{initial ? 'Edit lead' : 'Add lead'}</div>
+        <div className="grid grid-cols-2 gap-3">
+          <input className="border rounded p-2 col-span-2" placeholder="Имя"
+                 value={form.name ?? ''} onChange={e => set('name', e.target.value)} />
+          <input className="border rounded p-2 col-span-2" placeholder="Телефон"
+                 value={form.phone ?? ''} onChange={e => set('phone', e.target.value)} />
+          <select className="border rounded p-2 col-span-1" value={form.source ?? ''} onChange={e => set('source', e.target.value as Lead['source'])}>
+            <option value="">Источник</option>
+            <option value="instagram">Instagram</option>
+            <option value="whatsapp">WhatsApp</option>
+            <option value="telegram">Telegram</option>
+          </select>
+          <select className="border rounded p-2 col-span-1" value={form.stage ?? ''} onChange={e => set('stage', e.target.value as Lead['stage'])}>
+            <option value="">Стадия</option>
+            {LEAD_STAGES.map(s => (
+              <option key={s.key} value={s.key}>{s.title}</option>
+            ))}
+          </select>
+        </div>
+        <div className="flex justify-end gap-2">
+          <button className="px-3 py-2 rounded bg-gray-200" onClick={onClose}>Cancel</button>
+          <button className="px-3 py-2 rounded bg-blue-600 text-white" onClick={save}>Save</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/leadStages.ts
+++ b/lib/leadStages.ts
@@ -1,0 +1,8 @@
+export const LEAD_STAGES = [
+  { key: 'queue', title: 'Очередь' },
+  { key: 'hold', title: 'Задержка' },
+  { key: 'trial', title: 'Пробное' },
+  { key: 'awaiting_payment', title: 'Ожидание оплаты' },
+  { key: 'paid', title: 'Оплачено' },
+  { key: 'canceled', title: 'Отмена' },
+] as const;

--- a/pages/leads.tsx
+++ b/pages/leads.tsx
@@ -2,19 +2,14 @@ import { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
 import type { Lead } from '../lib/types';
 import LeadCard from '../components/LeadCard';
-
-const STAGES = [
-  { key: 'queue', title: 'Очередь' },
-  { key: 'hold', title: 'Задержка' },
-  { key: 'trial', title: 'Пробное' },
-  { key: 'awaiting_payment', title: 'Ожидание оплаты' },
-  { key: 'paid', title: 'Оплачено' },
-  { key: 'canceled', title: 'Отмена' },
-] as const;
+import LeadModal from '../components/LeadModal';
+import { LEAD_STAGES } from '../lib/leadStages';
 
 export default function LeadsPage() {
   const [leads, setLeads] = useState<Lead[]>([]);
   const [loading, setLoading] = useState(true);
+  const [openModal, setOpenModal] = useState(false);
+  const [editing, setEditing] = useState<Lead | null>(null);
 
   async function loadData() {
     setLoading(true);
@@ -28,12 +23,22 @@ export default function LeadsPage() {
 
   useEffect(() => { loadData(); }, []);
 
+  const openAdd = () => { setEditing(null); setOpenModal(true); };
+
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Leads</h1>
+      <div className="mb-4">
+        <button
+          onClick={openAdd}
+          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+        >
+          + Add Lead
+        </button>
+      </div>
       {loading && <div className="text-gray-500">loading…</div>}
       <div className="flex gap-4 overflow-x-auto">
-        {STAGES.map((stage) => (
+        {LEAD_STAGES.map((stage) => (
           <div key={stage.key} className="w-64 shrink-0">
             <h2 className="text-center font-semibold mb-2">{stage.title}</h2>
             {leads.filter((l) => l.stage === stage.key).map((l) => (
@@ -42,6 +47,13 @@ export default function LeadsPage() {
           </div>
         ))}
       </div>
+      {openModal && (
+        <LeadModal
+          initial={editing}
+          onClose={() => setOpenModal(false)}
+          onSaved={() => { setOpenModal(false); loadData(); }}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add 'Add Lead' button to leads page
- introduce modal to manually capture lead details and stage
- centralize lead stages constant

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c098580fa0832b8f3ec6e64dd08813