### PR TITLE
feat: expand groups by district and clients

### DIFF
--- a/components/GroupWithClients.tsx
+++ b/components/GroupWithClients.tsx
@@ -1,0 +1,58 @@
+'use client';
+import { useState } from 'react';
+import { supabase } from '../lib/supabaseClient';
+import GroupCard, { Group } from './GroupCard';
+import type { Client } from '../lib/types';
+
+type Props = {
+  group: Group;
+  onChanged?: () => void;
+};
+
+export default function GroupWithClients({ group, onChanged }: Props) {
+  const [open, setOpen] = useState(false);
+  const [clients, setClients] = useState<Client[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  async function toggle() {
+    if (!open && clients.length === 0) {
+      setLoading(true);
+      const { data, error } = await supabase
+        .from('client_groups')
+        .select('client:clients(id, first_name, last_name)')
+        .eq('group_id', group.id)
+        .returns<{ client: Client }[]>();
+      if (!error && data) {
+        setClients(data.map((r) => r.client));
+      }
+      setLoading(false);
+    }
+    setOpen(!open);
+  }
+
+  return (
+    <div className="space-y-2">
+      <GroupCard group={group} onChanged={onChanged} />
+      <button
+        className="text-sm text-blue-600 underline"
+        onClick={toggle}
+      >
+        {open ? 'Hide clients' : 'Show clients'}
+      </button>
+      {open && (
+        <div className="pl-4 space-y-1">
+          {loading && <div className="text-sm text-gray-500">loading…</div>}
+          {!loading && clients.length === 0 && (
+            <div className="text-sm text-gray-500">no clients</div>
+          )}
+          {clients.map((c) => (
+            <div key={c.id} className="text-sm">
+              {c.first_name}
+              {c.last_name ? ` ${c.last_name}` : ''}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/pages/groups.tsx
+++ b/pages/groups.tsx
@@ -1,11 +1,15 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '../lib/supabaseClient';
-import GroupCard, { Group } from '../components/GroupCard';
 import AddGroupModal from '../components/AddGroupModal';
+import GroupWithClients from '../components/GroupWithClients';
+import { Group } from '../components/GroupCard';
+
+const DISTRICTS = ['Центр', 'Джикджилли', 'Махмутлар'];
 
 export default function Home() {
   const [groups, setGroups] = useState<Group[]>([]);
   const [openAdd, setOpenAdd] = useState(false);
+  const [openDistricts, setOpenDistricts] = useState<Record<string, boolean>>({});
 
   async function loadData() {
     const { data, error } = await supabase
@@ -15,6 +19,10 @@ export default function Home() {
     if (!error && data) setGroups(data as Group[]);
   }
   useEffect(() => { loadData(); }, []);
+
+  const toggleDistrict = (d: string) => {
+    setOpenDistricts((prev) => ({ ...prev, [d]: !prev[d] }));
+  };
 
   return (
     <main className="min-h-screen bg-gray-100">
@@ -30,10 +38,26 @@ export default function Home() {
         </button>
       </div>
 
-      {/* Список групп */}
-      <div className="mt-6 space-y-3 max-w-3xl mx-auto px-4 pb-10">
-        {groups.map((g) => (
-          <GroupCard key={g.id} group={g} onChanged={loadData} />
+      {/* Список групп по районам */}
+      <div className="mt-6 space-y-4 max-w-3xl mx-auto px-4 pb-10">
+        {DISTRICTS.map((d) => (
+          <div key={d} className="border rounded-xl bg-white/70 shadow">
+            <button
+              className="w-full text-left px-4 py-2 font-semibold"
+              onClick={() => toggleDistrict(d)}
+            >
+              {d}
+            </button>
+            {openDistricts[d] && (
+              <div className="p-4 space-y-3">
+                {groups
+                  .filter((g) => g.district === d)
+                  .map((g) => (
+                    <GroupWithClients key={g.id} group={g} onChanged={loadData} />
+                  ))}
+              </div>
+            )}
+          </div>
         ))}
       </div>
 


### PR DESCRIPTION
## Summary
- display groups grouped by districts with expandable buttons
- allow expanding each group to list its clients

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c098e88748832b90d5b1184ceca968