### PR TITLE
Add attendance journal page

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -29,6 +29,7 @@ export default function NavBar() {
           <NavLink href="/clients">Clients</NavLink>
           <NavLink href="/leads">Leads</NavLink>
           <NavLink href="/payments">Payments</NavLink>
+          <NavLink href="/attendance">Attendance</NavLink>
         </nav>
       </div>
     </header>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -22,3 +22,10 @@ export type Lead = {
   source: 'instagram' | 'whatsapp' | 'telegram';
   stage: 'queue' | 'hold' | 'trial' | 'awaiting_payment' | 'paid' | 'canceled';
 };
+
+export type AttendanceRecord = {
+  id: string;
+  client_id: string;
+  date: string;
+  present: boolean;
+};

--- a/pages/attendance.tsx
+++ b/pages/attendance.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabaseClient';
+import { Client, AttendanceRecord } from '../lib/types';
+
+export default function AttendancePage() {
+  const [clients, setClients] = useState<Client[]>([]);
+  const [records, setRecords] = useState<Record<string, boolean>>({});
+  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10));
+
+  useEffect(() => {
+    (async () => {
+      const { data, error } = await supabase
+        .from('clients')
+        .select('id, first_name, last_name')
+        .order('first_name', { ascending: true });
+      if (!error && data) setClients(data as Client[]);
+    })();
+  }, []);
+
+  useEffect(() => {
+    (async () => {
+      const { data, error } = await supabase
+        .from('attendance')
+        .select('client_id, present')
+        .eq('date', date);
+      if (!error && data) {
+        const map: Record<string, boolean> = {};
+        (data as AttendanceRecord[]).forEach((r) => {
+          map[r.client_id] = r.present;
+        });
+        setRecords(map);
+      } else {
+        setRecords({});
+      }
+    })();
+  }, [date]);
+
+  async function toggle(clientId: string) {
+    const present = !records[clientId];
+    setRecords((prev) => ({ ...prev, [clientId]: present }));
+    const { error } = await supabase
+      .from('attendance')
+      .upsert({ client_id: clientId, date, present }, { onConflict: 'client_id,date' });
+    if (error) alert(error.message);
+  }
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Attendance</h1>
+      <div className="mb-4">
+        <input
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+          className="border rounded px-3 py-2"
+        />
+      </div>
+      <div className="space-y-2">
+        {clients.map((c) => (
+          <label key={c.id} className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={!!records[c.id]}
+              onChange={() => toggle(c.id)}
+            />
+            <span>
+              {c.first_name} {c.last_name}
+            </span>
+          </label>
+        ))}
+        {clients.length === 0 && (
+          <div className="text-gray-500">no clients</div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add attendance tracking page to mark client presence
- expose attendance page in navigation
- define AttendanceRecord type

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c09913e998832b8d1a25342aa51206