### PR TITLE
feat: add basic leads pipeline

### DIFF
--- a/components/LeadCard.tsx
+++ b/components/LeadCard.tsx
@@ -1,0 +1,45 @@
+import Link from 'next/link';
+import type { Lead, LeadStage } from '../lib/types';
+import { LEAD_STAGES, LEAD_SOURCE_TITLES } from '../lib/types';
+import { cn } from '../lib/utils';
+
+export type LeadCardProps = {
+  lead: Lead;
+  onStageChange: (id: number, stage: LeadStage) => void;
+  className?: string;
+};
+
+export default function LeadCard({ lead, onStageChange, className }: LeadCardProps) {
+  const createdAt = lead.created_at ? new Date(lead.created_at) : null;
+  const createdLabel =
+    createdAt && !Number.isNaN(createdAt.getTime())
+      ? new Intl.DateTimeFormat('ru-RU').format(createdAt)
+      : null;
+
+  return (
+    <div className={cn('bg-white rounded shadow p-2 mb-2', className)}>
+      <div className="flex items-start justify-between">
+        <div>
+          <div className="font-medium">{lead.name}</div>
+          {lead.phone && <div className="text-sm text-gray-500">{lead.phone}</div>}
+          {createdLabel && <div className="text-xs text-gray-400">{createdLabel}</div>}
+        </div>
+        <Link href={`/leads/${lead.id}`} className="text-xs text-blue-500">
+          View
+        </Link>
+      </div>
+      <select
+        className="mt-2 w-full border rounded text-sm"
+        value={lead.stage}
+        onChange={(e) => onStageChange(lead.id, e.target.value as LeadStage)}
+      >
+        {LEAD_STAGES.map((s) => (
+          <option key={s.key} value={s.key}>
+            {s.title}
+          </option>
+        ))}
+      </select>
+      <div className="text-xs text-gray-400 mt-1">{LEAD_SOURCE_TITLES[lead.source]}</div>
+    </div>
+  );
+}

--- a/components/LeadForm.tsx
+++ b/components/LeadForm.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import { LEAD_SOURCE_VALUES, LEAD_SOURCE_TITLES } from '../lib/types';
+import type { LeadSource } from '../lib/types';
+
+export default function LeadForm({
+  onAdd,
+}: {
+  onAdd: (data: { name: string; phone: string | null; source: LeadSource }) => Promise<void>;
+}) {
+  const [name, setName] = useState('');
+  const [phone, setPhone] = useState('');
+  const [source, setSource] = useState<LeadSource>('instagram');
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    await onAdd({ name, phone: phone || null, source });
+    setName('');
+    setPhone('');
+    setSource('instagram');
+  }
+
+  return (
+    <form onSubmit={submit} className="flex gap-2 mb-4 flex-wrap">
+      <input
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Имя"
+        className="border p-1 flex-1 min-w-[8rem]"
+        required
+      />
+      <input
+        value={phone}
+        onChange={(e) => setPhone(e.target.value)}
+        placeholder="Телефон"
+        className="border p-1 flex-1 min-w-[8rem]"
+      />
+      <select
+        value={source}
+        onChange={(e) => setSource(e.target.value as LeadSource)}
+        className="border p-1"
+      >
+        {LEAD_SOURCE_VALUES.map((s) => (
+          <option key={s} value={s}>
+            {LEAD_SOURCE_TITLES[s]}
+          </option>
+        ))}
+      </select>
+      <button
+        type="submit"
+        className="bg-blue-500 text-white px-3 py-1 rounded"
+      >
+        Добавить
+      </button>
+    </form>
+  );
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -13,3 +13,36 @@ export type Client = {
   payment_method: 'cash' | 'transfer' | null;
   district: string | null;
 };
+
+export const LEAD_SOURCE_VALUES = ['instagram', 'whatsapp', 'telegram'] as const;
+export type LeadSource = (typeof LEAD_SOURCE_VALUES)[number];
+
+export const LEAD_SOURCE_TITLES: Record<LeadSource, string> = {
+  instagram: 'Instagram',
+  whatsapp: 'WhatsApp',
+  telegram: 'Telegram',
+};
+
+export const LEAD_STAGES = [
+  { key: 'queue', title: 'Очередь' },
+  { key: 'hold', title: 'Задержка' },
+  { key: 'trial', title: 'Пробное' },
+  { key: 'awaiting_payment', title: 'Ожидание оплаты' },
+  { key: 'paid', title: 'Оплачено' },
+  { key: 'canceled', title: 'Отмена' },
+] as const;
+export type LeadStage = (typeof LEAD_STAGES)[number]['key'];
+
+export const LEAD_STAGE_TITLES: Record<LeadStage, string> = Object.fromEntries(
+  LEAD_STAGES.map((s) => [s.key, s.title])
+) as Record<LeadStage, string>;
+
+export type Lead = {
+  id: number;
+  created_at: string;
+  updated_at?: string | null;
+  name: string;
+  phone: string | null;
+  source: LeadSource;
+  stage: LeadStage;
+};

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ');
+}

--- a/pages/leads.tsx
+++ b/pages/leads.tsx
@@ -1,8 +1,97 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabaseClient';
+import {
+  LEAD_STAGES,
+  type Lead,
+  type LeadStage,
+  type LeadSource,
+} from '../lib/types';
+import LeadCard from '../components/LeadCard';
+import LeadForm from '../components/LeadForm';
+
+type StageMap = Record<LeadStage, Lead[]>;
+
+function emptyStageMap(): StageMap {
+  return LEAD_STAGES.reduce((acc, s) => {
+    acc[s.key] = [];
+    return acc;
+  }, {} as StageMap);
+}
+
 export default function LeadsPage() {
+  const [leads, setLeads] = useState<StageMap>(emptyStageMap());
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  async function loadData() {
+    setLoading(true);
+    const { data, error } = await supabase
+      .from('leads')
+      .select('id, created_at, name, phone, source, stage')
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      console.error(error);
+      setLoading(false);
+      return;
+    }
+
+    const grouped: StageMap = emptyStageMap();
+    for (const lead of data as Lead[]) {
+      grouped[lead.stage].push(lead);
+    }
+    setLeads(grouped);
+    setLoading(false);
+  }
+
+  async function addLead(data: { name: string; phone: string | null; source: LeadSource }) {
+    const { error } = await supabase.from('leads').insert({ ...data, stage: 'queue' });
+    if (error) {
+      console.error(error);
+      return;
+    }
+    await loadData();
+  }
+
+  async function changeStage(id: number, stage: LeadStage) {
+    const previous = leads;
+    setLeads((prev) => {
+      const updated: StageMap = emptyStageMap();
+      for (const s of LEAD_STAGES) {
+        updated[s.key] = prev[s.key].filter((l) => l.id !== id);
+      }
+      const current = Object.values(prev).flat().find((l) => l.id === id);
+      if (current) {
+        updated[stage] = [{ ...current, stage }, ...updated[stage]];
+      }
+      return updated;
+    });
+
+    const { error } = await supabase.from('leads').update({ stage }).eq('id', id);
+    if (error) {
+      console.error(error);
+      setLeads(previous);
+    }
+  }
+
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Leads</h1>
-      <p className="text-gray-600">Тут сделаем воронку (Queue → Trial → Awaiting payment → Paid), и конвертацию в клиента.</p>
+      <LeadForm onAdd={addLead} />
+      {loading && <div className="text-gray-500">loading…</div>}
+      <div className="flex gap-4 overflow-x-auto">
+        {LEAD_STAGES.map((stage) => (
+          <div key={stage.key} className="w-64 shrink-0">
+            <h2 className="text-center font-semibold mb-2">{stage.title}</h2>
+            {leads[stage.key].map((l) => (
+              <LeadCard key={l.id} lead={l} onStageChange={changeStage} />
+            ))}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- resolve merge conflicts with main and keep lead utilities centralized
- support adding leads and moving them through stages via `LeadForm` and `LeadCard`
- display leads grouped by stage with formatted dates and source labels
- derive the leads page stage map from shared constants to avoid duplication
- fix duplicate stage title import on leads page
- replace `date-fns` with built-in `Intl.DateTimeFormat` to avoid missing module errors
- rename `LEAD_SOURCES` constant to `LEAD_SOURCE_VALUES` to prevent redeclaration errors
- consolidate lead imports on leads page to avoid re-declaration of constants

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c0862e6be0832bbe8b584ff59008bc