### PR TITLE
Consolidate lead source definitions

### DIFF
--- a/components/LeadModal.tsx
+++ b/components/LeadModal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
 import type { Lead } from '../lib/types';
-import { LEAD_STAGES } from '../lib/leadStages';
+import { LEAD_STAGES } from '../lib/types';
 
 export default function LeadModal({
   initial,

--- a/lib/leadStages.ts
+++ b/lib/leadStages.ts
@@ -1,8 +1,0 @@
-export const LEAD_STAGES = [
-  { key: 'queue', title: 'Очередь' },
-  { key: 'hold', title: 'Задержка' },
-  { key: 'trial', title: 'Пробное' },
-  { key: 'awaiting_payment', title: 'Ожидание оплаты' },
-  { key: 'paid', title: 'Оплачено' },
-  { key: 'canceled', title: 'Отмена' },
-] as const;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -14,16 +14,6 @@ export type Client = {
   district: 'Центр' | 'Джикджилли' | 'Махмутлар' | null;
 };
 
-export type Lead = {
-  id: string;
-  created_at: string;
-  name: string;
-  phone: string | null;
-  source: 'instagram' | 'whatsapp' | 'telegram';
-  stage: 'queue' | 'hold' | 'trial' | 'awaiting_payment' | 'paid' | 'canceled';
-};
-
-
 export type AttendanceRecord = {
   id: string;
   client_id: string;
@@ -38,145 +28,12 @@ export type Task = {
   payment_id: string | null;
 };
 
-export const LEAD_SOURCES = ['instagram', 'whatsapp', 'telegram'] as const;
-export type LeadSource = (typeof LEAD_SOURCES)[number];
-
-export const LEAD_SOURCE_TITLES: Record<LeadSource, string> = {
-  instagram: 'Instagram',
-  whatsapp: 'WhatsApp',
-  telegram: 'Telegram',
-};
-
-export const LEAD_STAGES = [
-  { key: 'queue', title: 'Очередь' },
-  { key: 'hold', title: 'Задержка' },
-  { key: 'trial', title: 'Пробное' },
-  { key: 'awaiting_payment', title: 'Ожидание оплаты' },
-  { key: 'paid', title: 'Оплачено' },
-  { key: 'canceled', title: 'Отмена' },
-] as const;
-export type LeadStage = (typeof LEAD_STAGES)[number]['key'];
-
-export const LEAD_STAGE_TITLES: Record<LeadStage, string> = Object.fromEntries(
-  LEAD_STAGES.map((s) => [s.key, s.title])
-) as Record<LeadStage, string>;
-
-export type Lead = {
-  id: number;
-  created_at: string;
-  updated_at?: string | null;
-  name: string;
-  phone: string | null;
-  source: LeadSource;
-  stage: LeadStage;
-};
-
-export const LEAD_SOURCES = ['instagram', 'whatsapp', 'telegram'] as const;
-export type LeadSource = (typeof LEAD_SOURCES)[number];
-
-export const LEAD_SOURCE_TITLES: Record<LeadSource, string> = {
-  instagram: 'Instagram',
-  whatsapp: 'WhatsApp',
-  telegram: 'Telegram',
-};
-
-export const LEAD_STAGES = [
-  { key: 'queue', title: 'Очередь' },
-  { key: 'hold', title: 'Задержка' },
-  { key: 'trial', title: 'Пробное' },
-  { key: 'awaiting_payment', title: 'Ожидание оплаты' },
-  { key: 'paid', title: 'Оплачено' },
-  { key: 'canceled', title: 'Отмена' },
-] as const;
-export type LeadStage = (typeof LEAD_STAGES)[number]['key'];
-
-export const LEAD_STAGE_TITLES: Record<LeadStage, string> = Object.fromEntries(
-  LEAD_STAGES.map((s) => [s.key, s.title])
-) as Record<LeadStage, string>;
-
-export type Lead = {
-  id: number;
-  created_at: string;
-  updated_at?: string | null;
-  name: string;
-  phone: string | null;
-  source: LeadSource;
-  stage: LeadStage;
-};
-
-export const LEAD_SOURCE_VALUES = ['instagram', 'whatsapp', 'telegram'] as const;
-export type LeadSource = (typeof LEAD_SOURCE_VALUES)[number];
-
-export const LEAD_SOURCE_TITLES: Record<LeadSource, string> = {
-  instagram: 'Instagram',
-  whatsapp: 'WhatsApp',
-  telegram: 'Telegram',
-};
-
-export const LEAD_STAGES = [
-  { key: 'queue', title: 'Очередь' },
-  { key: 'hold', title: 'Задержка' },
-  { key: 'trial', title: 'Пробное' },
-  { key: 'awaiting_payment', title: 'Ожидание оплаты' },
-  { key: 'paid', title: 'Оплачено' },
-  { key: 'canceled', title: 'Отмена' },
-] as const;
-export type LeadStage = (typeof LEAD_STAGES)[number]['key'];
-
-export const LEAD_STAGE_TITLES: Record<LeadStage, string> = Object.fromEntries(
-  LEAD_STAGES.map((s) => [s.key, s.title])
-) as Record<LeadStage, string>;
-
-export type Lead = {
-  id: number;
-  created_at: string;
-  updated_at?: string | null;
-  name: string;
-  phone: string | null;
-  source: LeadSource;
-  stage: LeadStage;
-};
-
-export const LEAD_SOURCE_VALUES = ['instagram', 'whatsapp', 'telegram'] as const;
-export type LeadSource = (typeof LEAD_SOURCE_VALUES)[number];
-
-export const LEAD_SOURCE_TITLES: Record<LeadSource, string> = {
-  instagram: 'Instagram',
-  whatsapp: 'WhatsApp',
-  telegram: 'Telegram',
-};
-
-export const LEAD_STAGES = [
-  { key: 'queue', title: 'Очередь' },
-  { key: 'hold', title: 'Задержка' },
-  { key: 'trial', title: 'Пробное' },
-  { key: 'awaiting_payment', title: 'Ожидание оплаты' },
-  { key: 'paid', title: 'Оплачено' },
-  { key: 'canceled', title: 'Отмена' },
-] as const;
-export type LeadStage = (typeof LEAD_STAGES)[number]['key'];
-
-export const LEAD_STAGE_TITLES: Record<LeadStage, string> = Object.fromEntries(
-  LEAD_STAGES.map((s) => [s.key, s.title])
-) as Record<LeadStage, string>;
-
-export type Lead = {
-  id: number;
-  created_at: string;
-  updated_at?: string | null;
-  name: string;
-  phone: string | null;
-  source: LeadSource;
-  stage: LeadStage;
-};
-
 export const LEAD_SOURCES = [
   { key: 'instagram', title: 'Instagram' },
   { key: 'whatsapp', title: 'WhatsApp' },
   { key: 'telegram', title: 'Telegram' },
 ] as const;
 export type LeadSource = (typeof LEAD_SOURCES)[number]['key'];
-
 export const LEAD_SOURCE_TITLES: Record<LeadSource, string> = Object.fromEntries(
   LEAD_SOURCES.map((s) => [s.key, s.title])
 ) as Record<LeadSource, string>;
@@ -190,7 +47,6 @@ export const LEAD_STAGES = [
   { key: 'canceled', title: 'Отмена' },
 ] as const;
 export type LeadStage = (typeof LEAD_STAGES)[number]['key'];
-
 export const LEAD_STAGE_TITLES: Record<LeadStage, string> = Object.fromEntries(
   LEAD_STAGES.map((s) => [s.key, s.title])
 ) as Record<LeadStage, string>;


### PR DESCRIPTION
## Summary
- Remove duplicate lead source and stage constants
- Update LeadModal to use centralized stage list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68c13828def4832b8302c3fc53b1adab