### PR TITLE
Refactor groups section into districts and streamline client workflows

### DIFF
--- a/components/AddGroupForm.tsx
+++ b/components/AddGroupForm.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react'
 import { supabase } from '../lib/supabaseClient'
+import { DISTRICT_OPTIONS } from '../lib/districts'
 
 type Props = {
   onCreated?: () => void
 }
 
 export default function AddGroupForm({ onCreated }: Props) {
-  const [district, setDistrict] = useState('')
+  const [district, setDistrict] = useState<string>(DISTRICT_OPTIONS[0])
   const [ageBand, setAgeBand] = useState('')
   const [capacity, setCapacity] = useState<number | ''>('')
   const [loading, setLoading] = useState(false)
@@ -32,7 +33,7 @@ export default function AddGroupForm({ onCreated }: Props) {
       return
     }
     // очистим форму и обновим список
-    setDistrict('')
+    setDistrict(DISTRICT_OPTIONS[0])
     setAgeBand('')
     setCapacity('')
     onCreated?.()
@@ -41,12 +42,15 @@ export default function AddGroupForm({ onCreated }: Props) {
   return (
     <form onSubmit={handleSubmit} className="w-full max-w-xl mx-auto p-4 bg-white rounded-2xl shadow">
       <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-        <input
+        <select
           className="border rounded-lg px-3 py-2"
-          placeholder="Район (например, Центр)"
           value={district}
           onChange={(e) => setDistrict(e.target.value)}
-        />
+        >
+          {DISTRICT_OPTIONS.map((d) => (
+            <option key={d} value={d}>{d}</option>
+          ))}
+        </select>
         <input
           className="border rounded-lg px-3 py-2"
           placeholder="Возраст (например, 4-6 лет)"
@@ -71,7 +75,7 @@ export default function AddGroupForm({ onCreated }: Props) {
           disabled={loading}
           className="px-4 py-2 rounded-xl bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-60"
         >
-          {loading ? 'Добавляю…' : '+ Add Group'}
+          {loading ? 'Добавляю…' : '+ Добавить группу'}
         </button>
       </div>
     </form>

--- a/components/AddGroupModal.tsx
+++ b/components/AddGroupModal.tsx
@@ -1,18 +1,24 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
 
 type Props = {
   open: boolean;
   onClose: () => void;
   onCreated: () => void; // перезагрузить список
+  districts: string[];
+  initialDistrict?: string;
 };
 
-export default function AddGroupModal({ open, onClose, onCreated }: Props) {
-  const [district, setDistrict] = useState('');
+export default function AddGroupModal({ open, onClose, onCreated, districts, initialDistrict }: Props) {
+  const [district, setDistrict] = useState(initialDistrict ?? districts[0] ?? '');
   const [ageBand, setAgeBand] = useState('');
   const [capacity, setCapacity] = useState<number>(16);
   const [loading, setLoading] = useState(false);
   const disabled = loading || !district || !ageBand || !capacity;
+
+  useEffect(() => {
+    setDistrict(initialDistrict ?? districts[0] ?? '');
+  }, [initialDistrict, districts]);
 
   if (!open) return null;
 
@@ -38,12 +44,15 @@ export default function AddGroupModal({ open, onClose, onCreated }: Props) {
         <h3 className="text-xl font-semibold mb-4">Добавить группу</h3>
 
         <label className="block text-sm mb-1">Район</label>
-        <input
+        <select
           className="w-full border rounded px-3 py-2 mb-3"
-          placeholder="Напр. Центр, Махмутлар…"
           value={district}
           onChange={(e) => setDistrict(e.target.value)}
-        />
+        >
+          {districts.map((d) => (
+            <option key={d} value={d}>{d}</option>
+          ))}
+        </select>
 
         <label className="block text-sm mb-1">Возраст (диапазон)</label>
         <input

--- a/components/ClientModal.tsx
+++ b/components/ClientModal.tsx
@@ -1,15 +1,20 @@
 import React, { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
 import type { Client } from '../lib/types';
+import { DISTRICT_OPTIONS } from '../lib/districts';
 
 export default function ClientModal({
   initial,
   onClose,
   onSaved,
+  groupId,
+  districts = [...DISTRICT_OPTIONS],
 }: {
-  initial?: Client | null;
+  initial?: Partial<Client> | null;
   onClose: () => void;
-  onSaved: () => void;
+  onSaved: (client?: Client) => void;
+  groupId?: string;
+  districts?: string[];
 }) {
   const [form, setForm] = useState<Partial<Client>>({});
 
@@ -37,13 +42,20 @@ export default function ClientModal({
     };
 
     let error;
+    let data;
     if (initial?.id) {
       ({ error } = await supabase.from('clients').update(payload).eq('id', initial.id));
     } else {
-      ({ error } = await supabase.from('clients').insert(payload));
+      ({ data, error } = await supabase.from('clients').insert(payload).select().single());
+      if (!error && groupId && data) {
+        const { error: cgError } = await supabase
+          .from('client_groups')
+          .insert({ client_id: data.id, group_id: groupId });
+        if (cgError) { alert(cgError.message); return; }
+      }
     }
     if (error) { alert(error.message); return; }
-    onSaved();
+    onSaved(data as Client | undefined);
   };
 
   return (
@@ -109,9 +121,9 @@ export default function ClientModal({
             onChange={e => set('district', e.target.value || null)}
           >
             <option value="">Район</option>
-            <option value="Центр">Центр</option>
-            <option value="Джикджилли">Джикджилли</option>
-            <option value="Махмутлар">Махмутлар</option>
+            {districts.map((d) => (
+              <option key={d} value={d}>{d}</option>
+            ))}
           </select>
         </div>
         <div className="flex justify-end gap-2">

--- a/components/EditGroupDialog.tsx
+++ b/components/EditGroupDialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { supabase } from '../lib/supabaseClient'
 import type { Group } from './GroupCard'
+import { DISTRICT_OPTIONS } from '../lib/districts'
 
 type Props = {
   initial: Group
@@ -34,12 +35,15 @@ export default function EditGroupDialog({ initial, onClose, onSaved }: Props) {
 
         <form onSubmit={submit} className="space-y-3">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-            <input
+            <select
               className="border rounded-lg px-3 py-2"
-              placeholder="Район"
               value={district}
               onChange={(e) => setDistrict(e.target.value)}
-            />
+            >
+              {DISTRICT_OPTIONS.map((d) => (
+                <option key={d} value={d}>{d}</option>
+              ))}
+            </select>
             <input
               className="border rounded-lg px-3 py-2"
               placeholder="Возраст"

--- a/components/GroupCard.tsx
+++ b/components/GroupCard.tsx
@@ -12,9 +12,11 @@ export type Group = {
 type Props = {
   group: Group;
   onChanged?: () => void; // вызовем после update/delete
+  onAddClient?: () => void;
+  districts?: string[];
 };
 
-export default function GroupCard({ group, onChanged }: Props) {
+export default function GroupCard({ group, onChanged, onAddClient, districts }: Props) {
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [form, setForm] = useState({
@@ -57,7 +59,10 @@ export default function GroupCard({ group, onChanged }: Props) {
 
   if (!editing) {
     return (
-      <div className="border rounded-2xl bg-white/70 shadow p-4 flex items-start justify-between">
+      <div
+        className="border rounded-2xl bg-white/70 shadow p-4 flex items-start justify-between cursor-pointer"
+        onClick={onAddClient}
+      >
         <div>
           <div className="font-semibold">{group.age_band}</div>
           <div className="text-sm text-gray-600">
@@ -67,13 +72,13 @@ export default function GroupCard({ group, onChanged }: Props) {
         <div className="flex gap-2">
           <button
             className="px-3 py-1 rounded-lg bg-blue-600 text-white"
-            onClick={() => setEditing(true)}
+            onClick={(e) => { e.stopPropagation(); setEditing(true); }}
           >
             Edit
           </button>
           <button
             className="px-3 py-1 rounded-lg bg-red-600/90 text-white"
-            onClick={handleDelete}
+            onClick={(e) => { e.stopPropagation(); handleDelete(); }}
           >
             Delete
           </button>
@@ -87,11 +92,15 @@ export default function GroupCard({ group, onChanged }: Props) {
       <div className="grid grid-cols-3 gap-3">
         <label className="text-sm">
           Район
-          <input
+          <select
             className="mt-1 w-full rounded-lg border px-3 py-2"
             value={form.district}
             onChange={(e) => setForm({ ...form, district: e.target.value })}
-          />
+          >
+            {districts?.map((d) => (
+              <option key={d} value={d}>{d}</option>
+            ))}
+          </select>
         </label>
         <label className="text-sm">
           Возраст

--- a/components/GroupWithClients.tsx
+++ b/components/GroupWithClients.tsx
@@ -3,16 +3,19 @@ import { useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
 import GroupCard, { Group } from './GroupCard';
 import type { Client } from '../lib/types';
+import ClientModal from './ClientModal';
 
 type Props = {
   group: Group;
   onChanged?: () => void;
+  districts: string[];
 };
 
-export default function GroupWithClients({ group, onChanged }: Props) {
+export default function GroupWithClients({ group, onChanged, districts }: Props) {
   const [open, setOpen] = useState(false);
   const [clients, setClients] = useState<Client[]>([]);
   const [loading, setLoading] = useState(false);
+  const [openClient, setOpenClient] = useState(false);
 
   async function toggle() {
     if (!open && clients.length === 0) {
@@ -32,7 +35,12 @@ export default function GroupWithClients({ group, onChanged }: Props) {
 
   return (
     <div className="space-y-2">
-      <GroupCard group={group} onChanged={onChanged} />
+      <GroupCard
+        group={group}
+        onChanged={onChanged}
+        districts={districts}
+        onAddClient={() => setOpenClient(true)}
+      />
       <button
         className="text-sm text-blue-600 underline"
         onClick={toggle}
@@ -52,6 +60,15 @@ export default function GroupWithClients({ group, onChanged }: Props) {
             </div>
           ))}
         </div>
+      )}
+      {openClient && (
+        <ClientModal
+          initial={{ district: group.district }}
+          onClose={() => setOpenClient(false)}
+          onSaved={(c) => { if (c) setClients((prev) => [...prev, c]); setOpenClient(false); }}
+          groupId={group.id}
+          districts={districts}
+        />
       )}
     </div>
   );

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -22,7 +22,7 @@ export default function NavBar() {
         <Link href="/" className="text-xl font-bold text-blue-700">Judo CRM</Link>
         <nav className="flex gap-2">
           <NavLink href="/">Dashboard</NavLink>
-          <NavLink href="/groups">Groups</NavLink>
+          <NavLink href="/districts">Районы</NavLink>
           <NavLink href="/clients">Clients</NavLink>
           <NavLink href="/leads">Leads</NavLink>
           <NavLink href="/payments">Payments</NavLink>

--- a/lib/districts.ts
+++ b/lib/districts.ts
@@ -1,0 +1,2 @@
+export const DISTRICT_OPTIONS = ['Центр', 'Джикджилли', 'Махмутлар'] as const;
+export type District = (typeof DISTRICT_OPTIONS)[number];

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -11,7 +11,7 @@ export type Client = {
   gender: 'm' | 'f' | null;
   payment_status: 'pending' | 'active' | 'debt' | null;
   payment_method: 'cash' | 'transfer' | null;
-  district: 'Центр' | 'Джикджилли' | 'Махмутлар' | null;
+  district: string | null;
 };
 
 export type AttendanceRecord = {

--- a/pages/districts.tsx
+++ b/pages/districts.tsx
@@ -3,12 +3,13 @@ import { supabase } from '../lib/supabaseClient';
 import AddGroupModal from '../components/AddGroupModal';
 import GroupWithClients from '../components/GroupWithClients';
 import { Group } from '../components/GroupCard';
+import { DISTRICT_OPTIONS } from '../lib/districts';
 
-const DISTRICTS = ['Центр', 'Джикджилли', 'Махмутлар'];
-
-export default function Home() {
+export default function DistrictsPage() {
   const [groups, setGroups] = useState<Group[]>([]);
-  const [openAdd, setOpenAdd] = useState(false);
+  const [districts, setDistricts] = useState<string[]>([...DISTRICT_OPTIONS]);
+  const [openAddGroup, setOpenAddGroup] = useState(false);
+  const [selectedDistrict, setSelectedDistrict] = useState<string | null>(null);
   const [openDistricts, setOpenDistricts] = useState<Record<string, boolean>>({});
 
   async function loadData() {
@@ -24,6 +25,13 @@ export default function Home() {
     setOpenDistricts((prev) => ({ ...prev, [d]: !prev[d] }));
   };
 
+  const addDistrict = () => {
+    const name = prompt('Название района?')?.trim();
+    if (name && !districts.includes(name)) {
+      setDistricts([...districts, name]);
+    }
+  };
+
   return (
     <main className="min-h-screen bg-gray-100">
       <h1 className="text-4xl font-bold text-blue-600 text-center pt-10">Judo CRM</h1>
@@ -31,16 +39,16 @@ export default function Home() {
       {/* Панель действий */}
       <div className="max-w-3xl mx-auto px-4 mt-6">
         <button
-          onClick={() => setOpenAdd(true)}
+          onClick={addDistrict}
           className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
         >
-          + Add Group
+          + Добавить район
         </button>
       </div>
 
       {/* Список групп по районам */}
       <div className="mt-6 space-y-4 max-w-3xl mx-auto px-4 pb-10">
-        {DISTRICTS.map((d) => (
+        {districts.map((d) => (
           <div key={d} className="border rounded-xl bg-white/70 shadow">
             <button
               className="w-full text-left px-4 py-2 font-semibold"
@@ -53,19 +61,27 @@ export default function Home() {
                 {groups
                   .filter((g) => g.district === d)
                   .map((g) => (
-                    <GroupWithClients key={g.id} group={g} onChanged={loadData} />
+                    <GroupWithClients key={g.id} group={g} onChanged={loadData} districts={districts} />
                   ))}
+                <button
+                  onClick={() => { setSelectedDistrict(d); setOpenAddGroup(true); }}
+                  className="bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700"
+                >
+                  + Добавить группу
+                </button>
               </div>
             )}
           </div>
         ))}
       </div>
 
-      {/* Модалка создания */}
+      {/* Модалка создания группы */}
       <AddGroupModal
-        open={openAdd}
-        onClose={() => setOpenAdd(false)}
+        open={openAddGroup}
+        onClose={() => setOpenAddGroup(false)}
         onCreated={loadData}
+        districts={districts}
+        initialDistrict={selectedDistrict ?? undefined}
       />
     </main>
   );

--- a/src/app/AppCRM.tsx
+++ b/src/app/AppCRM.tsx
@@ -21,7 +21,7 @@ export default function AppCRM() {
         <main className="max-w-6xl mx-auto p-4 md:p-6">
           <Routes>
             <Route path="/" element={<DashboardPage />} />
-            <Route path="/groups" element={<GroupsPage />} />
+            <Route path="/districts" element={<DistrictsPage />} />
             <Route path="/clients" element={<ClientsPage />} />
             <Route path="/settings" element={<SettingsPage />} />
             <Route path="*" element={<NotFoundPage />} />
@@ -38,7 +38,7 @@ function TopNav() {
 
   const links = [
     { to: "/", label: "Главная", icon: <LayoutDashboard className="w-4 h-4" /> },
-    { to: "/groups", label: "Группы", icon: <Group className="w-4 h-4" /> },
+    { to: "/districts", label: "Районы", icon: <Group className="w-4 h-4" /> },
     { to: "/clients", label: "Клиенты", icon: <Users className="w-4 h-4" /> },
     { to: "/settings", label: "Настройки", icon: <Settings className="w-4 h-4" /> },
   ];
@@ -102,7 +102,7 @@ function DashboardPage() {
       <h1 className="text-2xl font-semibold">Добро пожаловать 👋</h1>
       <p className="text-gray-600">Здесь будет краткий обзор: количество групп, клиентов, ближайшие тренировки и задачи.</p>
       <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        <KPI title="Группы" value="7" />
+        <KPI title="Районы" value="7" />
         <KPI title="Клиенты" value="63" />
         <KPI title="Тренировки сегодня" value="3" />
         <KPI title="Задачи" value="5" />
@@ -120,7 +120,7 @@ function KPI({ title, value }: { title: string; value: string }) {
   );
 }
 
-function GroupsPage() {
+function DistrictsPage() {
   // Полноценный CRUD без поля «Название», как ты просил ранее
   type Group = { id: number; age: string; coach: string; loc: string };
 
@@ -177,7 +177,7 @@ function GroupsPage() {
   return (
     <section className="space-y-4">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold">Группы</h1>
+        <h1 className="text-2xl font-semibold">Районы</h1>
       </div>
 
       {/* Форма добавления */}


### PR DESCRIPTION
## Summary
- rename Groups navigation to "Районы" and update routes
- move "добавить группу" button into each district, add top-level "добавить район"
- clicking a group opens client creation with district preset and restrict district fields to dropdown options

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c150fad93c832b908c8f2af06a94d0