### PR TITLE
Preserve manual tasks when loading payment tasks

### DIFF
--- a/pages/tasks.tsx
+++ b/pages/tasks.tsx
@@ -20,7 +20,7 @@ export default function TasksPage() {
           completed: false,
           payment_id: p.id,
         }));
-        setTasks(paymentTasks);
+        setTasks((prev) => [...prev, ...paymentTasks]);
       }
     }
     loadFromPayments();


### PR DESCRIPTION
## Summary
- prevent loadFromPayments from overwriting manually added tasks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68c151b0af48832b92483514a0d45aa6