### PR TITLE
Add labels for client date fields

### DIFF
--- a/components/ClientModal.tsx
+++ b/components/ClientModal.tsx
@@ -53,66 +53,121 @@ export default function ClientModal({
           {initial ? 'Edit client' : 'Add client'}
         </div>
         <div className="grid grid-cols-2 gap-3">
-          <input className="border rounded p-2 col-span-1" placeholder="Имя"
-                 value={form.first_name ?? ''} onChange={e => set('first_name', e.target.value)} />
-          <input className="border rounded p-2 col-span-1" placeholder="Фамилия"
-                 value={form.last_name ?? ''} onChange={e => set('last_name', e.target.value)} />
-          <input className="border rounded p-2 col-span-1" placeholder="Телефон"
-                 value={form.phone ?? ''} onChange={e => set('phone', e.target.value)} />
-          <select className="border rounded p-2 col-span-1" value={form.channel ?? ''} onChange={e => set('channel', e.target.value || null)}>
-            <option value="">Канал</option>
-            <option value="whatsapp">WhatsApp</option>
-            <option value="telegram">Telegram</option>
-            <option value="instagram">Instagram</option>
-          </select>
-          <input
-            type="date"
-            className="border rounded p-2 col-span-1"
-            placeholder="Дата рождения"
-            aria-label="Дата рождения"
-            value={form.birth_date ?? ''}
-            onChange={e => set('birth_date', e.target.value)}
-          />
-          <input
-            className="border rounded p-2 col-span-1"
-            placeholder="Родитель"
-            value={form.parent_name ?? ''}
-            onChange={e => set('parent_name', e.target.value)}
-          />
-          <input
-            type="date"
-            className="border rounded p-2 col-span-1"
-            placeholder="Начало посещения"
-            aria-label="Начало посещения"
-            value={form.start_date ?? ''}
-            onChange={e => set('start_date', e.target.value)}
-          />
-          <select className="border rounded p-2 col-span-1" value={form.gender ?? ''} onChange={e => set('gender', e.target.value || null)}>
-            <option value="">Пол</option>
-            <option value="m">М</option>
-            <option value="f">Ж</option>
-          </select>
-          <select className="border rounded p-2 col-span-1" value={form.payment_status ?? ''} onChange={e => set('payment_status', e.target.value || null)}>
-            <option value="">Статус оплаты</option>
-            <option value="pending">Ожидает</option>
-            <option value="active">Активен</option>
-            <option value="debt">Долг</option>
-          </select>
-          <select className="border rounded p-2 col-span-1" value={form.payment_method ?? ''} onChange={e => set('payment_method', e.target.value || null)}>
-            <option value="">Способ оплаты</option>
-            <option value="cash">Нал</option>
-            <option value="transfer">Перевод</option>
-          </select>
-          <select
-            className="border rounded p-2 col-span-2"
-            value={form.district ?? ''}
-            onChange={e => set('district', e.target.value || null)}
-          >
-            <option value="">Район</option>
-            <option value="Центр">Центр</option>
-            <option value="Джикджилли">Джикджилли</option>
-            <option value="Махмутлар">Махмутлар</option>
-          </select>
+          <label className="col-span-1 flex flex-col">
+            <span className="text-sm text-gray-700">Имя</span>
+            <input
+              className="border rounded p-2"
+              value={form.first_name ?? ''}
+              onChange={e => set('first_name', e.target.value)}
+            />
+          </label>
+          <label className="col-span-1 flex flex-col">
+            <span className="text-sm text-gray-700">Фамилия</span>
+            <input
+              className="border rounded p-2"
+              value={form.last_name ?? ''}
+              onChange={e => set('last_name', e.target.value)}
+            />
+          </label>
+          <label className="col-span-1 flex flex-col">
+            <span className="text-sm text-gray-700">Телефон</span>
+            <input
+              className="border rounded p-2"
+              value={form.phone ?? ''}
+              onChange={e => set('phone', e.target.value)}
+            />
+          </label>
+          <label className="col-span-1 flex flex-col">
+            <span className="text-sm text-gray-700">Канал</span>
+            <select
+              className="border rounded p-2"
+              value={form.channel ?? ''}
+              onChange={e => set('channel', e.target.value || null)}
+            >
+              <option value="">Не выбран</option>
+              <option value="whatsapp">WhatsApp</option>
+              <option value="telegram">Telegram</option>
+              <option value="instagram">Instagram</option>
+            </select>
+          </label>
+          <label className="col-span-1 flex flex-col">
+            <span className="text-sm text-gray-700">Дата рождения</span>
+            <input
+              type="date"
+              className="border rounded p-2"
+              aria-label="Дата рождения"
+              value={form.birth_date ?? ''}
+              onChange={e => set('birth_date', e.target.value)}
+            />
+          </label>
+          <label className="col-span-1 flex flex-col">
+            <span className="text-sm text-gray-700">Родитель</span>
+            <input
+              className="border rounded p-2"
+              value={form.parent_name ?? ''}
+              onChange={e => set('parent_name', e.target.value)}
+            />
+          </label>
+          <label className="col-span-1 flex flex-col">
+            <span className="text-sm text-gray-700">Начало посещения</span>
+            <input
+              type="date"
+              className="border rounded p-2"
+              aria-label="Начало посещения"
+              value={form.start_date ?? ''}
+              onChange={e => set('start_date', e.target.value)}
+            />
+          </label>
+          <label className="col-span-1 flex flex-col">
+            <span className="text-sm text-gray-700">Пол</span>
+            <select
+              className="border rounded p-2"
+              value={form.gender ?? ''}
+              onChange={e => set('gender', e.target.value || null)}
+            >
+              <option value="">Не выбран</option>
+              <option value="m">М</option>
+              <option value="f">Ж</option>
+            </select>
+          </label>
+          <label className="col-span-1 flex flex-col">
+            <span className="text-sm text-gray-700">Статус оплаты</span>
+            <select
+              className="border rounded p-2"
+              value={form.payment_status ?? ''}
+              onChange={e => set('payment_status', e.target.value || null)}
+            >
+              <option value="">Не выбран</option>
+              <option value="pending">Ожидает</option>
+              <option value="active">Активен</option>
+              <option value="debt">Долг</option>
+            </select>
+          </label>
+          <label className="col-span-1 flex flex-col">
+            <span className="text-sm text-gray-700">Способ оплаты</span>
+            <select
+              className="border rounded p-2"
+              value={form.payment_method ?? ''}
+              onChange={e => set('payment_method', e.target.value || null)}
+            >
+              <option value="">Не выбран</option>
+              <option value="cash">Нал</option>
+              <option value="transfer">Перевод</option>
+            </select>
+          </label>
+          <label className="col-span-2 flex flex-col">
+            <span className="text-sm text-gray-700">Район</span>
+            <select
+              className="border rounded p-2"
+              value={form.district ?? ''}
+              onChange={e => set('district', e.target.value || null)}
+            >
+              <option value="">Не выбран</option>
+              <option value="Центр">Центр</option>
+              <option value="Джикджилли">Джикджилли</option>
+              <option value="Махмутлар">Махмутлар</option>
+            </select>
+          </label>
         </div>
         <div className="flex justify-end gap-2">
           <button className="px-3 py-2 rounded bg-gray-200" onClick={onClose}>Cancel</button>


### PR DESCRIPTION
## Summary
- clarify birth date and start date fields in client modal
- place consistent labels above all client fields

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1516b8924832b8dcd3faef1a8976b