### PR TITLE
Refactor groups section into districts and streamline client workflows

### DIFF
--- a/components/AddGroupForm.tsx
+++ b/components/AddGroupForm.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react'
 import { supabase } from '../lib/supabaseClient'
+import { DISTRICT_OPTIONS } from '../lib/districts'
 
 type Props = {
   onCreated?: () => void
 }
 
 export default function AddGroupForm({ onCreated }: Props) {
-  const [district, setDistrict] = useState('')
+  const [district, setDistrict] = useState<string>(DISTRICT_OPTIONS[0])
   const [ageBand, setAgeBand] = useState('')
   const [capacity, setCapacity] = useState<number | ''>('')
   const [loading, setLoading] = useState(false)
@@ -32,7 +33,7 @@ export default function AddGroupForm({ onCreated }: Props) {
       return
     }
     // очистим форму и обновим список
-    setDistrict('')
+    setDistrict(DISTRICT_OPTIONS[0])
     setAgeBand('')
     setCapacity('')
     onCreated?.()
@@ -41,12 +42,15 @@ export default function AddGroupForm({ onCreated }: Props) {
   return (
     <form onSubmit={handleSubmit} className="w-full max-w-xl mx-auto p-4 bg-white rounded-2xl shadow">
       <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-        <input
+        <select
           className="border rounded-lg px-3 py-2"
-          placeholder="Район (например, Центр)"
           value={district}
           onChange={(e) => setDistrict(e.target.value)}
-        />
+        >
+          {DISTRICT_OPTIONS.map((d) => (
+            <option key={d} value={d}>{d}</option>
+          ))}
+        </select>
         <input
           className="border rounded-lg px-3 py-2"
           placeholder="Возраст (например, 4-6 лет)"
@@ -71,7 +75,7 @@ export default function AddGroupForm({ onCreated }: Props) {
           disabled={loading}
           className="px-4 py-2 rounded-xl bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-60"
         >
-          {loading ? 'Добавляю…' : '+ Add Group'}
+          {loading ? 'Добавляю…' : '+ Добавить группу'}
         </button>
       </div>
     </form>

--- a/components/AddGroupModal.tsx
+++ b/components/AddGroupModal.tsx
@@ -1,18 +1,24 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
 
 type Props = {
   open: boolean;
   onClose: () => void;
   onCreated: () => void; // перезагрузить список
+  districts: string[];
+  initialDistrict?: string;
 };
 
-export default function AddGroupModal({ open, onClose, onCreated }: Props) {
-  const [district, setDistrict] = useState('');
+export default function AddGroupModal({ open, onClose, onCreated, districts, initialDistrict }: Props) {
+  const [district, setDistrict] = useState(initialDistrict ?? districts[0] ?? '');
   const [ageBand, setAgeBand] = useState('');
   const [capacity, setCapacity] = useState<number>(16);
   const [loading, setLoading] = useState(false);
   const disabled = loading || !district || !ageBand || !capacity;
+
+  useEffect(() => {
+    setDistrict(initialDistrict ?? districts[0] ?? '');
+  }, [initialDistrict, districts]);
 
   if (!open) return null;
 
@@ -38,12 +44,15 @@ export default function AddGroupModal({ open, onClose, onCreated }: Props) {
         <h3 className="text-xl font-semibold mb-4">Добавить группу</h3>
 
         <label className="block text-sm mb-1">Район</label>
-        <input
+        <select
           className="w-full border rounded px-3 py-2 mb-3"
-          placeholder="Напр. Центр, Махмутлар…"
           value={district}
           onChange={(e) => setDistrict(e.target.value)}
-        />
+        >
+          {districts.map((d) => (
+            <option key={d} value={d}>{d}</option>
+          ))}
+        </select>
 
         <label className="block text-sm mb-1">Возраст (диапазон)</label>
         <input
@@ -63,13 +72,13 @@ export default function AddGroupModal({ open, onClose, onCreated }: Props) {
         />
 
         <div className="flex justify-end gap-2">
-          <button onClick={onClose} className="px-4 py-2 rounded border">Cancel</button>
+          <button onClick={onClose} className="px-4 py-2 rounded border">Отмена</button>
           <button
             onClick={submit}
             disabled={disabled}
             className="px-4 py-2 rounded bg-blue-600 text-white disabled:opacity-50"
           >
-            {loading ? 'Saving…' : 'Create'}
+            {loading ? 'Сохраняю…' : 'Создать'}
           </button>
         </div>
       </div>

--- a/components/ClientCard.tsx
+++ b/components/ClientCard.tsx
@@ -23,8 +23,8 @@ export default function ClientCard({
           </div>
         </div>
         <div className="flex gap-2">
-          <button className="px-3 py-1 rounded bg-blue-600 text-white" onClick={() => onEdit(client)}>Edit</button>
-          <button className="px-3 py-1 rounded bg-red-600 text-white" onClick={() => onDelete(client.id)}>Delete</button>
+          <button className="px-3 py-1 rounded bg-blue-600 text-white" onClick={() => onEdit(client)}>Редактировать</button>
+          <button className="px-3 py-1 rounded bg-red-600 text-white" onClick={() => onDelete(client.id)}>Удалить</button>
         </div>
       </div>
       {children && <div className="mt-3">{children}</div>}

--- a/components/ClientGroupPicker.tsx
+++ b/components/ClientGroupPicker.tsx
@@ -86,7 +86,7 @@ export default function ClientGroupPicker({
   }
 
   if (loading) {
-    return <div className="text-sm text-gray-500">loading groups…</div>;
+    return <div className="text-sm text-gray-500">загрузка групп…</div>;
   }
 
   return (
@@ -94,7 +94,7 @@ export default function ClientGroupPicker({
       {/* Назначенные группы — чипсы */}
       <div className="flex flex-wrap gap-2">
         {clientGroupIds.length === 0 && (
-          <span className="text-sm text-gray-500">not assigned</span>
+          <span className="text-sm text-gray-500">не назначено</span>
         )}
         {allGroups
           .filter((g) => assigned.has(g.id))
@@ -108,7 +108,7 @@ export default function ClientGroupPicker({
                 disabled={saving}
                 onClick={() => remove(g.id)}
                 className="ml-1 rounded-full bg-blue-100 hover:bg-blue-200 px-2"
-                title="Remove"
+                title="Удалить"
               >
                 ×
               </button>
@@ -129,7 +129,7 @@ export default function ClientGroupPicker({
           disabled={saving}
         >
           <option value="" disabled>
-            + add to group…
+            + добавить в группу…
           </option>
           {allGroups
             .filter((g) => !assigned.has(g.id))
@@ -139,7 +139,7 @@ export default function ClientGroupPicker({
               </option>
             ))}
         </select>
-        {saving && <span className="text-xs text-gray-400">saving…</span>}
+        {saving && <span className="text-xs text-gray-400">сохранение…</span>}
       </div>
     </div>
   );

--- a/components/ClientModal.tsx
+++ b/components/ClientModal.tsx
@@ -1,15 +1,20 @@
 import React, { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
 import type { Client } from '../lib/types';
+import { DISTRICT_OPTIONS } from '../lib/districts';
 
 export default function ClientModal({
   initial,
   onClose,
   onSaved,
+  groupId,
+  districts = [...DISTRICT_OPTIONS],
 }: {
-  initial?: Client | null;
+  initial?: Partial<Client> | null;
   onClose: () => void;
-  onSaved: () => void;
+  onSaved: (client?: Client) => void;
+  groupId?: string;
+  districts?: string[];
 }) {
   const [form, setForm] = useState<Partial<Client>>({});
 
@@ -37,20 +42,27 @@ export default function ClientModal({
     };
 
     let error;
+    let data;
     if (initial?.id) {
       ({ error } = await supabase.from('clients').update(payload).eq('id', initial.id));
     } else {
-      ({ error } = await supabase.from('clients').insert(payload));
+      ({ data, error } = await supabase.from('clients').insert(payload).select().single());
+      if (!error && groupId && data) {
+        const { error: cgError } = await supabase
+          .from('client_groups')
+          .insert({ client_id: data.id, group_id: groupId });
+        if (cgError) { alert(cgError.message); return; }
+      }
     }
     if (error) { alert(error.message); return; }
-    onSaved();
+    onSaved(data as Client | undefined);
   };
 
   return (
     <div className="fixed inset-0 bg-black/30 flex items-center justify-center p-4">
       <div className="bg-white rounded-2xl p-4 w-full max-w-lg space-y-3">
         <div className="text-lg font-semibold">
-          {initial ? 'Edit client' : 'Add client'}
+          {initial ? 'Редактировать клиента' : 'Добавить клиента'}
         </div>
         <div className="grid grid-cols-2 gap-3">
           <input className="border rounded p-2 col-span-1" placeholder="Имя"
@@ -109,14 +121,14 @@ export default function ClientModal({
             onChange={e => set('district', e.target.value || null)}
           >
             <option value="">Район</option>
-            <option value="Центр">Центр</option>
-            <option value="Джикджилли">Джикджилли</option>
-            <option value="Махмутлар">Махмутлар</option>
+            {districts.map((d) => (
+              <option key={d} value={d}>{d}</option>
+            ))}
           </select>
         </div>
         <div className="flex justify-end gap-2">
-          <button className="px-3 py-2 rounded bg-gray-200" onClick={onClose}>Cancel</button>
-          <button className="px-3 py-2 rounded bg-blue-600 text-white" onClick={save}>Save</button>
+          <button className="px-3 py-2 rounded bg-gray-200" onClick={onClose}>Отмена</button>
+          <button className="px-3 py-2 rounded bg-blue-600 text-white" onClick={save}>Сохранить</button>
         </div>
       </div>
     </div>

--- a/components/EditGroupDialog.tsx
+++ b/components/EditGroupDialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { supabase } from '../lib/supabaseClient'
 import type { Group } from './GroupCard'
+import { DISTRICT_OPTIONS } from '../lib/districts'
 
 type Props = {
   initial: Group
@@ -34,12 +35,15 @@ export default function EditGroupDialog({ initial, onClose, onSaved }: Props) {
 
         <form onSubmit={submit} className="space-y-3">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-            <input
+            <select
               className="border rounded-lg px-3 py-2"
-              placeholder="Район"
               value={district}
               onChange={(e) => setDistrict(e.target.value)}
-            />
+            >
+              {DISTRICT_OPTIONS.map((d) => (
+                <option key={d} value={d}>{d}</option>
+              ))}
+            </select>
             <input
               className="border rounded-lg px-3 py-2"
               placeholder="Возраст"

--- a/components/GroupCard.tsx
+++ b/components/GroupCard.tsx
@@ -12,9 +12,11 @@ export type Group = {
 type Props = {
   group: Group;
   onChanged?: () => void; // вызовем после update/delete
+  onAddClient?: () => void;
+  districts?: string[];
 };
 
-export default function GroupCard({ group, onChanged }: Props) {
+export default function GroupCard({ group, onChanged, onAddClient, districts }: Props) {
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [form, setForm] = useState({
@@ -57,7 +59,10 @@ export default function GroupCard({ group, onChanged }: Props) {
 
   if (!editing) {
     return (
-      <div className="border rounded-2xl bg-white/70 shadow p-4 flex items-start justify-between">
+      <div
+        className="border rounded-2xl bg-white/70 shadow p-4 flex items-start justify-between cursor-pointer"
+        onClick={onAddClient}
+      >
         <div>
           <div className="font-semibold">{group.age_band}</div>
           <div className="text-sm text-gray-600">
@@ -66,16 +71,22 @@ export default function GroupCard({ group, onChanged }: Props) {
         </div>
         <div className="flex gap-2">
           <button
-            className="px-3 py-1 rounded-lg bg-blue-600 text-white"
-            onClick={() => setEditing(true)}
+            className="px-3 py-1 rounded-lg bg-blue-400 text-white hover:bg-blue-500"
+            onClick={(e) => { e.stopPropagation(); onAddClient?.(); }}
           >
-            Edit
+            Добавить клиента
+          </button>
+          <button
+            className="px-3 py-1 rounded-lg bg-blue-600 text-white"
+            onClick={(e) => { e.stopPropagation(); setEditing(true); }}
+          >
+            Редактировать
           </button>
           <button
             className="px-3 py-1 rounded-lg bg-red-600/90 text-white"
-            onClick={handleDelete}
+            onClick={(e) => { e.stopPropagation(); handleDelete(); }}
           >
-            Delete
+            Удалить
           </button>
         </div>
       </div>
@@ -87,11 +98,15 @@ export default function GroupCard({ group, onChanged }: Props) {
       <div className="grid grid-cols-3 gap-3">
         <label className="text-sm">
           Район
-          <input
+          <select
             className="mt-1 w-full rounded-lg border px-3 py-2"
             value={form.district}
             onChange={(e) => setForm({ ...form, district: e.target.value })}
-          />
+          >
+            {districts?.map((d) => (
+              <option key={d} value={d}>{d}</option>
+            ))}
+          </select>
         </label>
         <label className="text-sm">
           Возраст
@@ -129,14 +144,14 @@ export default function GroupCard({ group, onChanged }: Props) {
           }}
           disabled={saving}
         >
-          Cancel
+          Отмена
         </button>
         <button
           className="px-3 py-2 rounded-lg bg-blue-600 text-white"
           onClick={handleSave}
           disabled={saving}
         >
-          {saving ? 'Saving…' : 'Save'}
+          {saving ? 'Сохраняю…' : 'Сохранить'}
         </button>
       </div>
     </div>

--- a/components/GroupWithClients.tsx
+++ b/components/GroupWithClients.tsx
@@ -3,16 +3,19 @@ import { useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
 import GroupCard, { Group } from './GroupCard';
 import type { Client } from '../lib/types';
+import ClientModal from './ClientModal';
 
 type Props = {
   group: Group;
   onChanged?: () => void;
+  districts: string[];
 };
 
-export default function GroupWithClients({ group, onChanged }: Props) {
+export default function GroupWithClients({ group, onChanged, districts }: Props) {
   const [open, setOpen] = useState(false);
   const [clients, setClients] = useState<Client[]>([]);
   const [loading, setLoading] = useState(false);
+  const [openClient, setOpenClient] = useState(false);
 
   async function toggle() {
     if (!open && clients.length === 0) {
@@ -32,18 +35,23 @@ export default function GroupWithClients({ group, onChanged }: Props) {
 
   return (
     <div className="space-y-2">
-      <GroupCard group={group} onChanged={onChanged} />
+      <GroupCard
+        group={group}
+        onChanged={onChanged}
+        districts={districts}
+        onAddClient={() => setOpenClient(true)}
+      />
       <button
         className="text-sm text-blue-600 underline"
         onClick={toggle}
       >
-        {open ? 'Hide clients' : 'Show clients'}
+        {open ? 'Скрыть клиентов' : 'Показать клиентов'}
       </button>
       {open && (
         <div className="pl-4 space-y-1">
-          {loading && <div className="text-sm text-gray-500">loading…</div>}
+          {loading && <div className="text-sm text-gray-500">Загрузка…</div>}
           {!loading && clients.length === 0 && (
-            <div className="text-sm text-gray-500">no clients</div>
+            <div className="text-sm text-gray-500">Клиентов нет</div>
           )}
           {clients.map((c) => (
             <div key={c.id} className="text-sm">
@@ -52,6 +60,15 @@ export default function GroupWithClients({ group, onChanged }: Props) {
             </div>
           ))}
         </div>
+      )}
+      {openClient && (
+        <ClientModal
+          initial={{ district: group.district }}
+          onClose={() => setOpenClient(false)}
+          onSaved={(c) => { if (c) setClients((prev) => [...prev, c]); setOpenClient(false); }}
+          groupId={group.id}
+          districts={districts}
+        />
       )}
     </div>
   );

--- a/components/LeadCard.tsx
+++ b/components/LeadCard.tsx
@@ -25,7 +25,7 @@ export default function LeadCard({ lead, onStageChange, className }: LeadCardPro
           {createdLabel && <div className="text-xs text-gray-400">{createdLabel}</div>}
         </div>
         <Link href={`/leads/${lead.id}`} className="text-xs text-blue-500">
-          View
+          Открыть
         </Link>
       </div>
       <select

--- a/components/LeadModal.tsx
+++ b/components/LeadModal.tsx
@@ -41,7 +41,7 @@ export default function LeadModal({
   return (
     <div className="fixed inset-0 bg-black/30 flex items-center justify-center p-4">
       <div className="bg-white rounded-2xl p-4 w-full max-w-lg space-y-3">
-        <div className="text-lg font-semibold">{initial ? 'Edit lead' : 'Add lead'}</div>
+        <div className="text-lg font-semibold">{initial ? 'Редактировать лид' : 'Добавить лид'}</div>
         <div className="grid grid-cols-2 gap-3">
           <input className="border rounded p-2 col-span-2" placeholder="Имя"
                  value={form.name ?? ''} onChange={e => set('name', e.target.value)} />
@@ -61,8 +61,8 @@ export default function LeadModal({
           </select>
         </div>
         <div className="flex justify-end gap-2">
-          <button className="px-3 py-2 rounded bg-gray-200" onClick={onClose}>Cancel</button>
-          <button className="px-3 py-2 rounded bg-blue-600 text-white" onClick={save}>Save</button>
+          <button className="px-3 py-2 rounded bg-gray-200" onClick={onClose}>Отмена</button>
+          <button className="px-3 py-2 rounded bg-blue-600 text-white" onClick={save}>Сохранить</button>
         </div>
       </div>
     </div>

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -21,12 +21,12 @@ export default function NavBar() {
       <div className="max-w-5xl mx-auto px-4 h-14 flex items-center justify-between">
         <Link href="/" className="text-xl font-bold text-blue-700">Judo CRM</Link>
         <nav className="flex gap-2">
-          <NavLink href="/">Dashboard</NavLink>
-          <NavLink href="/groups">Groups</NavLink>
-          <NavLink href="/clients">Clients</NavLink>
-          <NavLink href="/leads">Leads</NavLink>
-          <NavLink href="/payments">Payments</NavLink>
-          <NavLink href="/tasks">Tasks</NavLink>
+          <NavLink href="/">Главная</NavLink>
+          <NavLink href="/districts">Районы</NavLink>
+          <NavLink href="/clients">Клиенты</NavLink>
+          <NavLink href="/leads">Лиды</NavLink>
+          <NavLink href="/payments">Платежи</NavLink>
+          <NavLink href="/tasks">Задачи</NavLink>
           <NavLink href="/attendance">Журнал посещений</NavLink>
         </nav>
       </div>

--- a/lib/districts.ts
+++ b/lib/districts.ts
@@ -1,0 +1,2 @@
+export const DISTRICT_OPTIONS = ['Центр', 'Джикджилли', 'Махмутлар'] as const;
+export type District = (typeof DISTRICT_OPTIONS)[number];

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -11,7 +11,7 @@ export type Client = {
   gender: 'm' | 'f' | null;
   payment_status: 'pending' | 'active' | 'debt' | null;
   payment_method: 'cash' | 'transfer' | null;
-  district: 'Центр' | 'Джикджилли' | 'Махмутлар' | null;
+  district: string | null;
 };
 
 export type AttendanceRecord = {

--- a/pages/clients.tsx
+++ b/pages/clients.tsx
@@ -27,34 +27,34 @@ export default function ClientsPage() {
   const openEdit = (c: Client) => { setEditing(c); setOpenModal(true); };
 
   const remove = async (id: string) => {
-    if (!confirm('Delete client?')) return;
+    if (!confirm('Удалить клиента?')) return;
     const { error } = await supabase.from('clients').delete().eq('id', id);
     if (error) alert(error.message); else loadData();
   };
 
   return (
     <div>
-      <h1 className="text-2xl font-bold mb-4">Clients</h1>
+      <h1 className="text-2xl font-bold mb-4">Клиенты</h1>
       <div className="mb-4">
         <button
           onClick={openAdd}
           className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
         >
-          + Add Client
+          + Добавить клиента
         </button>
       </div>
-      {loading && <div className="text-gray-500">loading…</div>}
+      {loading && <div className="text-gray-500">Загрузка…</div>}
       <div className="space-y-3">
         {clients.map((c) => (
           <ClientCard key={c.id} client={c} onEdit={openEdit} onDelete={remove}>
             <div>
-              <div className="text-xs uppercase text-gray-400 mb-1">Groups</div>
+              <div className="text-xs uppercase text-gray-400 mb-1">Группы</div>
               <ClientGroupPicker clientId={c.id} />
             </div>
           </ClientCard>
         ))}
         {!loading && clients.length === 0 && (
-          <div className="text-gray-500">no clients yet</div>
+          <div className="text-gray-500">Клиентов нет</div>
         )}
       </div>
       {openModal && (

--- a/pages/districts.tsx
+++ b/pages/districts.tsx
@@ -3,12 +3,13 @@ import { supabase } from '../lib/supabaseClient';
 import AddGroupModal from '../components/AddGroupModal';
 import GroupWithClients from '../components/GroupWithClients';
 import { Group } from '../components/GroupCard';
+import { DISTRICT_OPTIONS } from '../lib/districts';
 
-const DISTRICTS = ['Центр', 'Джикджилли', 'Махмутлар'];
-
-export default function Home() {
+export default function DistrictsPage() {
   const [groups, setGroups] = useState<Group[]>([]);
-  const [openAdd, setOpenAdd] = useState(false);
+  const [districts, setDistricts] = useState<string[]>([...DISTRICT_OPTIONS]);
+  const [openAddGroup, setOpenAddGroup] = useState(false);
+  const [selectedDistrict, setSelectedDistrict] = useState<string | null>(null);
   const [openDistricts, setOpenDistricts] = useState<Record<string, boolean>>({});
 
   async function loadData() {
@@ -24,23 +25,30 @@ export default function Home() {
     setOpenDistricts((prev) => ({ ...prev, [d]: !prev[d] }));
   };
 
+  const addDistrict = () => {
+    const name = prompt('Название района?')?.trim();
+    if (name && !districts.includes(name)) {
+      setDistricts([...districts, name]);
+    }
+  };
+
   return (
     <main className="min-h-screen bg-gray-100">
-      <h1 className="text-4xl font-bold text-blue-600 text-center pt-10">Judo CRM</h1>
+      <h1 className="text-4xl font-bold text-blue-600 text-center pt-10">Районы</h1>
 
       {/* Панель действий */}
       <div className="max-w-3xl mx-auto px-4 mt-6">
         <button
-          onClick={() => setOpenAdd(true)}
-          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+          onClick={addDistrict}
+          className="bg-blue-200 text-blue-900 px-4 py-2 rounded hover:bg-blue-300"
         >
-          + Add Group
+          + Добавить район
         </button>
       </div>
 
       {/* Список групп по районам */}
       <div className="mt-6 space-y-4 max-w-3xl mx-auto px-4 pb-10">
-        {DISTRICTS.map((d) => (
+        {districts.map((d) => (
           <div key={d} className="border rounded-xl bg-white/70 shadow">
             <button
               className="w-full text-left px-4 py-2 font-semibold"
@@ -53,19 +61,27 @@ export default function Home() {
                 {groups
                   .filter((g) => g.district === d)
                   .map((g) => (
-                    <GroupWithClients key={g.id} group={g} onChanged={loadData} />
+                    <GroupWithClients key={g.id} group={g} onChanged={loadData} districts={districts} />
                   ))}
+                <button
+                  onClick={() => { setSelectedDistrict(d); setOpenAddGroup(true); }}
+                  className="bg-blue-300 text-blue-900 px-3 py-1 rounded hover:bg-blue-400"
+                >
+                  + Добавить группу
+                </button>
               </div>
             )}
           </div>
         ))}
       </div>
 
-      {/* Модалка создания */}
+      {/* Модалка создания группы */}
       <AddGroupModal
-        open={openAdd}
-        onClose={() => setOpenAdd(false)}
+        open={openAddGroup}
+        onClose={() => setOpenAddGroup(false)}
         onCreated={loadData}
+        districts={districts}
+        initialDistrict={selectedDistrict ?? undefined}
       />
     </main>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 export default function Dashboard() {
   return (
     <div className="space-y-4">
-      <h1 className="text-3xl font-bold">Dashboard</h1>
+      <h1 className="text-3xl font-bold">Главная</h1>
       <p className="text-gray-600">Здесь позже появятся KPI: активные клиенты, посещаемость, выручка и т.д.</p>
     </div>
   );

--- a/pages/leads.tsx
+++ b/pages/leads.tsx
@@ -79,9 +79,9 @@ export default function LeadsPage() {
 
   return (
     <div>
-      <h1 className="text-2xl font-bold mb-4">Leads</h1>
+      <h1 className="text-2xl font-bold mb-4">Лиды</h1>
       <LeadForm onAdd={addLead} />
-      {loading && <div className="text-gray-500">loading…</div>}
+      {loading && <div className="text-gray-500">Загрузка…</div>}
       <div className="flex gap-4 overflow-x-auto">
         {LEAD_STAGES.map((stage) => (
           <div key={stage.key} className="w-64 shrink-0">

--- a/pages/payments.tsx
+++ b/pages/payments.tsx
@@ -1,7 +1,7 @@
 export default function PaymentsPage() {
   return (
     <div>
-      <h1 className="text-2xl font-bold mb-4">Payments</h1>
+      <h1 className="text-2xl font-bold mb-4">Платежи</h1>
       <p className="text-gray-600">Тут будут платежи, фильтры и виджеты выручки.</p>
     </div>
   );

--- a/pages/tasks.tsx
+++ b/pages/tasks.tsx
@@ -48,20 +48,20 @@ export default function TasksPage() {
 
   return (
     <div>
-      <h1 className="text-2xl font-bold mb-4">Tasks</h1>
+      <h1 className="text-2xl font-bold mb-4">Задачи</h1>
       <div className="flex gap-2 mb-4">
         <input
           type="text"
           className="border px-2 py-1 rounded flex-1"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
-          placeholder="New task..."
+          placeholder="Новая задача..."
         />
         <button
           onClick={addTask}
           className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
         >
-          + Add Task
+          + Добавить задачу
         </button>
       </div>
       <ul className="space-y-2">
@@ -79,7 +79,7 @@ export default function TasksPage() {
           </li>
         ))}
         {tasks.length === 0 && (
-          <div className="text-gray-500">no tasks yet</div>
+          <div className="text-gray-500">Задач пока нет</div>
         )}
       </ul>
     </div>

--- a/src/app/AppCRM.tsx
+++ b/src/app/AppCRM.tsx
@@ -21,7 +21,7 @@ export default function AppCRM() {
         <main className="max-w-6xl mx-auto p-4 md:p-6">
           <Routes>
             <Route path="/" element={<DashboardPage />} />
-            <Route path="/groups" element={<GroupsPage />} />
+            <Route path="/districts" element={<DistrictsPage />} />
             <Route path="/clients" element={<ClientsPage />} />
             <Route path="/settings" element={<SettingsPage />} />
             <Route path="*" element={<NotFoundPage />} />
@@ -38,7 +38,7 @@ function TopNav() {
 
   const links = [
     { to: "/", label: "Главная", icon: <LayoutDashboard className="w-4 h-4" /> },
-    { to: "/groups", label: "Группы", icon: <Group className="w-4 h-4" /> },
+    { to: "/districts", label: "Районы", icon: <Group className="w-4 h-4" /> },
     { to: "/clients", label: "Клиенты", icon: <Users className="w-4 h-4" /> },
     { to: "/settings", label: "Настройки", icon: <Settings className="w-4 h-4" /> },
   ];
@@ -102,7 +102,7 @@ function DashboardPage() {
       <h1 className="text-2xl font-semibold">Добро пожаловать 👋</h1>
       <p className="text-gray-600">Здесь будет краткий обзор: количество групп, клиентов, ближайшие тренировки и задачи.</p>
       <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        <KPI title="Группы" value="7" />
+        <KPI title="Районы" value="7" />
         <KPI title="Клиенты" value="63" />
         <KPI title="Тренировки сегодня" value="3" />
         <KPI title="Задачи" value="5" />
@@ -120,7 +120,7 @@ function KPI({ title, value }: { title: string; value: string }) {
   );
 }
 
-function GroupsPage() {
+function DistrictsPage() {
   // Полноценный CRUD без поля «Название», как ты просил ранее
   type Group = { id: number; age: string; coach: string; loc: string };
 
@@ -177,7 +177,7 @@ function GroupsPage() {
   return (
     <section className="space-y-4">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold">Группы</h1>
+        <h1 className="text-2xl font-semibold">Районы</h1>
       </div>
 
       {/* Форма добавления */}

--- a/src/pages/ClientsPage.tsx
+++ b/src/pages/ClientsPage.tsx
@@ -47,7 +47,7 @@ export default function ClientsPage() {
 
   return (
     <div style={{ padding: "24px" }}>
-      <h1 style={{ fontSize: 28, fontWeight: 600, marginBottom: 16 }}>Clients</h1>
+      <h1 style={{ fontSize: 28, fontWeight: 600, marginBottom: 16 }}>Клиенты</h1>
 
       {/* Форма добавления */}
       <form
@@ -65,25 +65,25 @@ export default function ClientsPage() {
         }}
       >
         <input
-          placeholder="Full name"
+          placeholder="ФИО"
           value={form.name}
           onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
           style={inputStyle}
         />
         <input
-          placeholder="Phone"
+          placeholder="Телефон"
           value={form.phone}
           onChange={(e) => setForm((f) => ({ ...f, phone: e.target.value }))}
           style={inputStyle}
         />
         <input
-          placeholder="Group ID (optional)"
+          placeholder="ID группы (необязательно)"
           value={form.group}
           onChange={(e) => setForm((f) => ({ ...f, group: e.target.value }))}
           style={inputStyle}
         />
         <button type="submit" style={primaryBtnStyle}>
-          Add client
+          Добавить клиента
         </button>
       </form>
 
@@ -93,17 +93,17 @@ export default function ClientsPage() {
           <thead>
             <tr style={{ background: "#f9fafb", color: "#6b7280" }}>
               <th style={thTd}>#</th>
-              <th style={thTd}>Name</th>
-              <th style={thTd}>Phone</th>
-              <th style={thTd}>Group</th>
-              <th style={thTd}>Actions</th>
+              <th style={thTd}>Имя</th>
+              <th style={thTd}>Телефон</th>
+              <th style={thTd}>Группа</th>
+              <th style={thTd}>Действия</th>
             </tr>
           </thead>
           <tbody>
             {items.length === 0 ? (
               <tr>
                 <td style={emptyCell} colSpan={5}>
-                  no clients yet
+                  Клиентов нет
                 </td>
               </tr>
             ) : (
@@ -115,10 +115,10 @@ export default function ClientsPage() {
                   <td style={thTd}>{c.group ?? "—"}</td>
                   <td style={thTd}>
                     <button style={secondaryBtnStyle} onClick={() => alert("Open client card (stub)")}>
-                      Open
+                      Открыть
                     </button>{" "}
                     <button style={secondaryBtnStyle} onClick={() => removeClient(c.id)}>
-                      Delete
+                      Удалить
                     </button>
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
- rename Groups navigation to "Районы" and update routes
- move "добавить группу" button into each district, add top-level "добавить район"
- clicking a group opens client creation with district preset and restrict district fields to dropdown options
- add explicit "Добавить клиента" button on each group card
- style add controls with muted, distinct blue tones
- translate remaining UI labels to Russian across navigation, dialogs and pages

## Testing
- `npm run lint`
- `NEXT_PUBLIC_SUPABASE_URL='http://localhost' NEXT_PUBLIC_SUPABASE_ANON_KEY='dummy' npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c150fad93c832b908c8f2af06a94d0