### PR TITLE
Add task district and client associations

### DIFF
--- a/lib/tasks.ts
+++ b/lib/tasks.ts
@@ -1,0 +1,37 @@
+import type { Task } from './types';
+import { supabase } from './supabaseClient';
+
+export async function fetchTasks(): Promise<Task[]> {
+  const { data, error } = await supabase.from('tasks').select('*');
+  if (error) throw error;
+  return (data as Task[]) || [];
+}
+
+export async function createTask(task: Omit<Task, 'id'>): Promise<Task> {
+  const { data, error } = await supabase
+    .from('tasks')
+    .insert(task)
+    .select()
+    .single();
+  if (error) throw error;
+  return data as Task;
+}
+
+export async function updateTask(
+  id: string,
+  updates: Partial<Task>
+): Promise<Task> {
+  const { data, error } = await supabase
+    .from('tasks')
+    .update(updates)
+    .eq('id', id)
+    .select()
+    .single();
+  if (error) throw error;
+  return data as Task;
+}
+
+export async function deleteTask(id: string): Promise<void> {
+  const { error } = await supabase.from('tasks').delete().eq('id', id);
+  if (error) throw error;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,5 @@
+export type District = 'Центр' | 'Джикджилли' | 'Махмутлар';
+
 export type Client = {
   id: string;
   created_at: string;
@@ -11,7 +13,7 @@ export type Client = {
   gender: 'm' | 'f' | null;
   payment_status: 'pending' | 'active' | 'debt' | null;
   payment_method: 'cash' | 'transfer' | null;
-  district: 'Центр' | 'Джикджилли' | 'Махмутлар' | null;
+  district: District | null;
 };
 
 export type AttendanceRecord = {
@@ -21,11 +23,28 @@ export type AttendanceRecord = {
   present: boolean;
 };
 
+export type TaskTag = 'rent' | 'payment' | 'birthday' | 'other';
+
+export const TASK_TAG_TITLES: Record<TaskTag, string> = {
+  rent: 'Аренда',
+  payment: 'Платеж',
+  birthday: 'День рождения',
+  other: 'Другое',
+};
+
+export type RecurrenceInterval = 'weekly' | 'monthly' | 'yearly';
+
 export type Task = {
   id: string;
   title: string;
   completed: boolean;
   payment_id: string | null;
+  is_recurring: boolean;
+  due_date: string | null;
+  recurring_interval: RecurrenceInterval | null;
+  tag: TaskTag;
+  district: District | null;
+  client_id: string | null;
 };
 
 export const LEAD_SOURCES = [

--- a/pages/tasks.tsx
+++ b/pages/tasks.tsx
@@ -1,85 +1,277 @@
 import { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
-import type { Task } from '../lib/types';
+import { TASK_TAG_TITLES } from '../lib/types';
+import type {
+  Task,
+  TaskTag,
+  Client,
+  District,
+  RecurrenceInterval,
+} from '../lib/types';
+import { createTask, fetchTasks, updateTask, deleteTask } from '../lib/tasks';
 
 type Payment = { id: string; client_id: string };
+
+const INTERVAL_LABELS: Record<RecurrenceInterval, string> = {
+  weekly: 'еженед.',
+  monthly: 'ежемес.',
+  yearly: 'ежегод.',
+};
 
 export default function TasksPage() {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [title, setTitle] = useState('');
+  const [dueDate, setDueDate] = useState('');
+  const [isRecurring, setIsRecurring] = useState(false);
+  const [recurringInterval, setRecurringInterval] =
+    useState<RecurrenceInterval>('monthly');
+  const [tag, setTag] = useState<TaskTag>('other');
+  const [district, setDistrict] = useState<District>('Центр');
+  const [clients, setClients] = useState<Client[]>([]);
+  const [clientId, setClientId] = useState('');
+  const [showForm, setShowForm] = useState(false);
 
   useEffect(() => {
-    async function loadFromPayments() {
-      const { data, error } = await supabase
-        .from('payments')
-        .select('id, client_id');
-      if (!error && data) {
-        const paymentTasks: Task[] = (data as Payment[]).map((p) => ({
-          id: `payment-${p.id}`,
-          title: `Обработать оплату клиента ${p.client_id}`,
-          completed: false,
-          payment_id: p.id,
-        }));
-        setTasks(paymentTasks);
+    async function load() {
+      try {
+        const dbTasks = await fetchTasks();
+        setTasks(dbTasks);
+        const { data, error } = await supabase
+          .from('payments')
+          .select('id, client_id');
+        if (!error && data) {
+          const paymentTasks: Task[] = (data as Payment[]).map((p) => ({
+            id: `payment-${p.id}`,
+            title: `Обработать оплату клиента ${p.client_id}`,
+            completed: false,
+            payment_id: p.id,
+            is_recurring: false,
+            due_date: null,
+            recurring_interval: null,
+            tag: 'payment',
+            district: null,
+            client_id: p.client_id,
+          }));
+          setTasks((prev) => [...prev, ...paymentTasks]);
+        }
+
+        const { data: clientsData } = await supabase
+          .from('clients')
+          .select('id, first_name, last_name');
+        if (clientsData) {
+          setClients(clientsData as Client[]);
+        }
+      } catch (err) {
+        console.error(err);
       }
     }
-    loadFromPayments();
+    load();
   }, []);
 
-  const addTask = () => {
-    if (!title.trim()) return;
-    const newTask: Task = {
-      id: `manual-${Date.now()}`,
+  const addTask = async () => {
+    if (!title.trim()) {
+      return;
+    }
+    const task = await createTask({
       title: title.trim(),
       completed: false,
       payment_id: null,
-    };
-    setTasks((prev) => [...prev, newTask]);
+      is_recurring: isRecurring,
+      due_date: dueDate || null,
+      recurring_interval: isRecurring ? recurringInterval : null,
+      tag,
+      district,
+      client_id: clientId || null,
+    });
+    setTasks((prev) => [...prev, task]);
     setTitle('');
+    setDueDate('');
+    setRecurringInterval('monthly');
+    setIsRecurring(false);
+    setTag('other');
+    setDistrict('Центр');
+    setClientId('');
+    setShowForm(false);
   };
 
-  const toggle = (id: string) => {
+  const toggle = async (id: string) => {
+    const task = tasks.find((t) => t.id === id);
+    if (!task) return;
+    const updated = !task.completed;
     setTasks((prev) =>
-      prev.map((t) =>
-        t.id === id ? { ...t, completed: !t.completed } : t
-      )
+      prev.map((t) => (t.id === id ? { ...t, completed: updated } : t))
     );
+    if (!id.startsWith('payment-')) {
+      await updateTask(id, { completed: updated });
+    }
+  };
+
+  const remove = async (id: string) => {
+    setTasks((prev) => prev.filter((t) => t.id !== id));
+    if (!id.startsWith('payment-')) {
+      await deleteTask(id);
+    }
   };
 
   return (
     <div>
-      <h1 className="text-2xl font-bold mb-4">Tasks</h1>
-      <div className="flex gap-2 mb-4">
-        <input
-          type="text"
-          className="border px-2 py-1 rounded flex-1"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          placeholder="New task..."
-        />
+      <h1 className="text-2xl font-bold mb-4">Задачи</h1>
+      <div className="mb-4">
         <button
-          onClick={addTask}
+          onClick={() => setShowForm(true)}
           className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
         >
-          + Add Task
+          + Добавить задачу
         </button>
       </div>
+      {showForm && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black/50">
+          <div className="bg-white p-4 rounded space-y-2 w-80">
+            <input
+              type="text"
+              className="border px-2 py-1 rounded w-full"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Название задачи"
+              autoFocus
+            />
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <label className="text-sm flex items-center gap-1">
+                  <input
+                    type="checkbox"
+                    checked={isRecurring}
+                    onChange={(e) => setIsRecurring(e.target.checked)}
+                  />
+                  Регулярная
+                </label>
+                {isRecurring && (
+                  <select
+                    className="border px-2 py-1 rounded"
+                    value={recurringInterval}
+                    onChange={(e) =>
+                      setRecurringInterval(e.target.value as RecurrenceInterval)
+                    }
+                  >
+                    <option value="weekly">Раз в неделю</option>
+                    <option value="monthly">Раз в месяц</option>
+                    <option value="yearly">Раз в год</option>
+                  </select>
+                )}
+              </div>
+              <input
+                type="date"
+                className="border px-2 py-1 rounded w-full"
+                value={dueDate}
+                onChange={(e) => setDueDate(e.target.value)}
+              />
+            </div>
+            <select
+              className="border px-2 py-1 rounded w-full"
+              value={district}
+              onChange={(e) => setDistrict(e.target.value as District)}
+            >
+              <option value="Центр">Центр</option>
+              <option value="Джикджилли">Джикджилли</option>
+              <option value="Махмутлар">Махмутлар</option>
+            </select>
+            <select
+              className="border px-2 py-1 rounded w-full"
+              value={clientId}
+              onChange={(e) => setClientId(e.target.value)}
+            >
+              <option value="">Клиент</option>
+              {clients.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.first_name} {c.last_name ?? ''}
+                </option>
+              ))}
+            </select>
+            <select
+              className="border px-2 py-1 rounded w-full"
+              value={tag}
+              onChange={(e) => setTag(e.target.value as TaskTag)}
+            >
+              <option value="rent">Аренда</option>
+              <option value="payment">Платеж</option>
+              <option value="birthday">День рождения</option>
+              <option value="other">Другое</option>
+            </select>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => {
+                  setShowForm(false);
+                  setTitle('');
+                  setDueDate('');
+                  setRecurringInterval('monthly');
+                  setIsRecurring(false);
+                  setTag('other');
+                  setDistrict('Центр');
+                  setClientId('');
+                }}
+                className="px-3 py-1 border rounded"
+              >
+                Отмена
+              </button>
+              <button
+                onClick={addTask}
+                className="bg-blue-600 text-white px-3 py-1 rounded"
+              >
+                Сохранить
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
       <ul className="space-y-2">
         {tasks.map((task) => (
-          <li key={task.id} className="flex items-center">
+          <li key={task.id} className="flex items-center gap-2">
             <input
               type="checkbox"
               checked={task.completed}
               onChange={() => toggle(task.id)}
-              className="mr-2"
             />
-            <span className={task.completed ? 'line-through text-gray-500' : ''}>
+            <span
+              className={task.completed ? 'line-through text-gray-500' : ''}
+            >
               {task.title}
             </span>
+            {task.due_date && (
+              <span className="text-sm text-gray-500">{task.due_date}</span>
+            )}
+            {task.is_recurring && task.recurring_interval && (
+              <span className="text-xs bg-gray-200 px-2 py-0.5 rounded">
+                {INTERVAL_LABELS[task.recurring_interval]}
+              </span>
+            )}
+            {task.district && (
+              <span className="text-xs bg-green-100 px-2 py-0.5 rounded">
+                {task.district}
+              </span>
+            )}
+            {task.client_id && (
+              <span className="text-xs bg-purple-100 px-2 py-0.5 rounded">
+                {(() => {
+                  const c = clients.find((c) => c.id === task.client_id);
+                  return c
+                    ? `${c.first_name} ${c.last_name ?? ''}`
+                    : task.client_id;
+                })()}
+              </span>
+            )}
+            <span className="ml-auto text-xs bg-blue-100 px-2 py-0.5 rounded">
+              {TASK_TAG_TITLES[task.tag]}
+            </span>
+            <button
+              onClick={() => remove(task.id)}
+              className="text-red-600 hover:text-red-800"
+            >
+              ×
+            </button>
           </li>
         ))}
         {tasks.length === 0 && (
-          <div className="text-gray-500">no tasks yet</div>
+          <div className="text-gray-500">Задач пока нет</div>
         )}
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- define reusable `District` type and extend tasks with `district` and `client_id`
- fetch client list and allow selecting district and client when creating tasks
- show recurring reminder day, district, and linked client on the tasks page
- allow specifying recurring task date and interval (weekly/monthly/yearly)
- localize task interface and tag labels to Russian

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `NEXT_PUBLIC_SUPABASE_URL=http://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c151b0af48832b92483514a0d45aa6