### PR TITLE
feat: add toast notifications

### DIFF
--- a/components/ClientModal.tsx
+++ b/components/ClientModal.tsx
@@ -3,6 +3,19 @@ import { supabase } from '../lib/supabaseClient';
 import type { Client } from '../lib/types';
 import { DISTRICT_OPTIONS } from '../lib/districts';
 
+function Toast({ message, onClose }: { message: string; onClose: () => void }) {
+  useEffect(() => {
+    const t = setTimeout(onClose, 3000);
+    return () => clearTimeout(t);
+  }, [onClose]);
+
+  return (
+    <div className="fixed top-4 right-4 bg-red-500 text-white px-4 py-2 rounded shadow">
+      {message}
+    </div>
+  );
+}
+
 export default function ClientModal({
   initial,
   onClose,
@@ -17,6 +30,7 @@ export default function ClientModal({
   districts?: string[];
 }) {
   const [form, setForm] = useState<Partial<Client>>({});
+  const [toast, setToast] = useState<string | null>(null);
 
   useEffect(() => { setForm(initial ?? {}); }, [initial]);
 
@@ -25,7 +39,7 @@ export default function ClientModal({
 
   const save = async () => {
     // валидация минимальная
-    if (!form.first_name) { alert('Введите имя'); return; }
+    if (!form.first_name) { setToast('Введите имя'); return; }
 
     const basePayload = {
       first_name: form.first_name,
@@ -54,13 +68,15 @@ export default function ClientModal({
         .from('clients')
         .insert({ ...basePayload, user_id: user?.id }));
     }
-    if (error) { alert(error.message); return; }
+    if (error) { setToast(error.message); return; }
     onSaved(data as Client | undefined);
   };
 
   return (
-    <div className="fixed inset-0 bg-black/30 flex items-center justify-center p-4">
-      <div className="bg-white rounded-2xl p-4 w-full max-w-lg space-y-3">
+    <>
+      {toast && <Toast message={toast} onClose={() => setToast(null)} />}
+      <div className="fixed inset-0 bg-black/30 flex items-center justify-center p-4">
+        <div className="bg-white rounded-2xl p-4 w-full max-w-lg space-y-3">
         <div className="text-lg font-semibold">
           {initial ? 'Редактировать клиента' : 'Добавить клиента'}
         </div>
@@ -186,6 +202,7 @@ export default function ClientModal({
           <button className="px-3 py-2 rounded bg-blue-600 text-white" onClick={save}>Сохранить</button>
         </div>
       </div>
-    </div>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add inline Toast component for error messages in client form
- use toast notifications for validation and save errors instead of alerts

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c167ad3cf8832b80005cf7a20669ea