### PR TITLE
fix: define LeadForm and add lead action

### DIFF
--- a/pages/leads.tsx
+++ b/pages/leads.tsx
@@ -4,9 +4,11 @@ import {
   LEAD_STAGES,
   type Lead,
   type LeadStage,
+  type LeadSource,
 } from '../lib/types';
 import LeadCard from '../components/LeadCard';
 import LeadModal from '../components/LeadModal';
+import LeadForm from '../components/LeadForm';
 
 type StageMap = Record<LeadStage, Lead[]>;
 
@@ -66,6 +68,25 @@ export default function LeadsPage() {
       console.error(error);
       setLeads(previous);
     }
+  }
+
+  async function addLead({
+    name,
+    phone,
+    source,
+  }: {
+    name: string;
+    phone: string | null;
+    source: LeadSource;
+  }) {
+    const { error } = await supabase
+      .from('leads')
+      .insert({ name, phone, source, stage: 'queue' });
+    if (error) {
+      console.error(error);
+      return;
+    }
+    await loadData();
   }
 
   return (


### PR DESCRIPTION
## Summary
- import LeadForm and LeadSource in leads page
- add addLead handler to create a new lead and reload data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c16bc1aca0832b820c994fa7e9adfc