### PR TITLE
Ensure newly added leads appear

### DIFF
--- a/pages/leads.tsx
+++ b/pages/leads.tsx
@@ -79,13 +79,23 @@ export default function LeadsPage() {
     phone: string | null;
     source: LeadSource;
   }) {
-    const { error } = await supabase
+    const { data, error } = await supabase
       .from('leads')
-      .insert({ name, phone, source, stage: 'queue' });
+      .insert({ name, phone, source, stage: 'queue' })
+      .select(
+        'id, created_at, name, phone, source, stage, birth_date, district, group_id'
+      )
+      .single();
     if (error) {
       console.error(error);
-      return;
+    } else if (data) {
+      setLeads((prev) => ({
+        ...prev,
+        queue: [data as Lead, ...prev.queue],
+      }));
     }
+
+    // Refresh leads to ensure UI stays in sync even if the inserted row isn't returned
     await loadData();
   }
 


### PR DESCRIPTION
## Summary
- Reload leads after insertion so UI shows new entry even if Supabase insert doesn't return data
- Always refresh lead list regardless of insert result

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c170cce62c832ba3e3fccb54c61ead