### PR TITLE
Ensure newly added leads appear

### DIFF
--- a/pages/leads.tsx
+++ b/pages/leads.tsx
@@ -79,13 +79,28 @@ export default function LeadsPage() {
     phone: string | null;
     source: LeadSource;
   }) {
-    const { error } = await supabase
+    const { data, error } = await supabase
       .from('leads')
-      .insert({ name, phone, source, stage: 'queue' });
+      .insert({ name, phone, source, stage: 'queue' })
+      .select(
+        'id, created_at, name, phone, source, stage, birth_date, district, group_id'
+      )
+      .single();
     if (error) {
       console.error(error);
+      await loadData();
       return;
     }
+
+    if (data) {
+      setLeads((prev) => ({
+        ...prev,
+        queue: [data as Lead, ...prev.queue],
+      }));
+      return;
+    }
+
+    // If Supabase didn't return the inserted row, reload the list
     await loadData();
   }
 


### PR DESCRIPTION
## Summary
- Only refresh leads list when Supabase insert doesn't return the new row

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c170cce62c832ba3e3fccb54c61ead