### PR TITLE
Ensure newly added leads appear

### DIFF
--- a/pages/leads.tsx
+++ b/pages/leads.tsx
@@ -23,6 +23,7 @@ export default function LeadsPage() {
   const [leads, setLeads] = useState<StageMap>(emptyStageMap());
   const [loading, setLoading] = useState(false);
   const [openModal, setOpenModal] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   useEffect(() => {
     loadData();
@@ -30,6 +31,7 @@ export default function LeadsPage() {
 
   async function loadData() {
     setLoading(true);
+    setErrorMsg(null);
     const { data, error } = await supabase
       .from('leads')
       .select('id, created_at, name, phone, source, stage, birth_date, district, group_id')
@@ -37,6 +39,7 @@ export default function LeadsPage() {
 
     if (error) {
       console.error(error);
+      setErrorMsg(error.message);
       setLoading(false);
       return;
     }
@@ -79,13 +82,30 @@ export default function LeadsPage() {
     phone: string | null;
     source: LeadSource;
   }) {
-    const { error } = await supabase
+    setErrorMsg(null);
+    const { data, error } = await supabase
       .from('leads')
-      .insert({ name, phone, source, stage: 'queue' });
+      .insert({ name, phone, source, stage: 'queue' })
+      .select(
+        'id, created_at, name, phone, source, stage, birth_date, district, group_id'
+      )
+      .single();
     if (error) {
       console.error(error);
+      setErrorMsg(error.message);
+      await loadData();
       return;
     }
+
+    if (data) {
+      setLeads((prev) => ({
+        ...prev,
+        queue: [data as Lead, ...prev.queue],
+      }));
+      return;
+    }
+
+    // If Supabase didn't return the inserted row, reload the list
     await loadData();
   }
 
@@ -93,6 +113,7 @@ export default function LeadsPage() {
     <div>
       <h1 className="text-2xl font-bold mb-4">Лиды</h1>
       <LeadForm onAdd={addLead} />
+      {errorMsg && <div className="text-red-600 mb-2">{errorMsg}</div>}
       {loading && <div className="text-gray-500">Загрузка…</div>}
       <div className="flex gap-4 overflow-x-auto">
         {LEAD_STAGES.map((stage) => (


### PR DESCRIPTION
## Summary
- Only refresh leads list when Supabase insert doesn't return the new row
- Display Supabase errors when loading or inserting leads

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c170cce62c832ba3e3fccb54c61ead