### PR TITLE
Ensure newly added leads appear

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -78,7 +78,7 @@ export type Lead = {
   phone: string | null;
   source: LeadSource;
   stage: LeadStage;
-  birth_date: string | null;
-  district: 'Центр' | 'Джикджилли' | 'Махмутлар' | null;
-  group_id: string | null;
+  birth_date?: string | null;
+  district?: 'Центр' | 'Джикджилли' | 'Махмутлар' | null;
+  group_id?: string | null;
 };


### PR DESCRIPTION
## Summary
- Only refresh leads list when Supabase insert doesn't return the new row
- Display Supabase errors when loading or inserting leads
- Avoid selecting lead columns that might not exist in Supabase

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c170cce62c832ba3e3fccb54c61ead