### PR TITLE
Add draggable lead cards and richer lead creation

### DIFF
--- a/components/LeadCard.tsx
+++ b/components/LeadCard.tsx
@@ -1,15 +1,14 @@
-import Link from 'next/link';
-import type { Lead, LeadStage } from '../lib/types';
-import { LEAD_STAGES, LEAD_SOURCE_TITLES } from '../lib/types';
+import type { Lead } from '../lib/types';
+import { LEAD_SOURCE_TITLES } from '../lib/types';
 import { cn } from '../lib/utils';
 
 export type LeadCardProps = {
   lead: Lead;
-  onStageChange: (id: number, stage: LeadStage) => void;
+  onOpen: (lead: Lead) => void;
   className?: string;
 };
 
-export default function LeadCard({ lead, onStageChange, className }: LeadCardProps) {
+export default function LeadCard({ lead, onOpen, className }: LeadCardProps) {
   const createdAt = lead.created_at ? new Date(lead.created_at) : null;
   const createdLabel =
     createdAt && !Number.isNaN(createdAt.getTime())
@@ -17,28 +16,21 @@ export default function LeadCard({ lead, onStageChange, className }: LeadCardPro
       : null;
 
   return (
-    <div className={cn('bg-white rounded shadow p-2 mb-2', className)}>
-      <div className="flex items-start justify-between">
-        <div>
-          <div className="font-medium">{lead.name}</div>
-          {lead.phone && <div className="text-sm text-gray-500">{lead.phone}</div>}
-          {createdLabel && <div className="text-xs text-gray-400">{createdLabel}</div>}
+    <div
+      className={cn('bg-white rounded shadow p-2 mb-2 cursor-move', className)}
+      draggable
+      onDragStart={(e) => e.dataTransfer.setData('id', String(lead.id))}
+    >
+      <div>
+        <div
+          className="font-medium cursor-pointer"
+          onClick={() => onOpen(lead)}
+        >
+          {lead.name}
         </div>
-        <Link href={`/leads/${lead.id}`} className="text-xs text-blue-500">
-          Подробнее
-        </Link>
+        {lead.phone && <div className="text-sm text-gray-500">{lead.phone}</div>}
+        {createdLabel && <div className="text-xs text-gray-400">{createdLabel}</div>}
       </div>
-      <select
-        className="mt-2 w-full border rounded text-sm"
-        value={lead.stage}
-        onChange={(e) => onStageChange(lead.id, e.target.value as LeadStage)}
-      >
-        {LEAD_STAGES.map((s) => (
-          <option key={s.key} value={s.key}>
-            {s.title}
-          </option>
-        ))}
-      </select>
       <div className="text-xs text-gray-400 mt-1">{LEAD_SOURCE_TITLES[lead.source]}</div>
     </div>
   );

--- a/components/LeadForm.tsx
+++ b/components/LeadForm.tsx
@@ -1,22 +1,57 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabaseClient';
 import { LEAD_SOURCES } from '../lib/types';
-import type { LeadSource } from '../lib/types';
+import type { LeadSource, District } from '../lib/types';
+import { DISTRICT_OPTIONS } from '../lib/districts';
+
+type Group = { id: string; district: string; age_band: string; name?: string | null };
 
 export default function LeadForm({
   onAdd,
 }: {
-  onAdd: (data: { name: string; phone: string | null; source: LeadSource }) => Promise<void>;
+  onAdd: (data: {
+    name: string;
+    phone: string | null;
+    source: LeadSource;
+    birth_date: string | null;
+    district: District | null;
+    group_id: string | null;
+  }) => Promise<void>;
 }) {
   const [name, setName] = useState('');
   const [phone, setPhone] = useState('');
   const [source, setSource] = useState<LeadSource>('instagram');
+  const [birthDate, setBirthDate] = useState('');
+  const [district, setDistrict] = useState<District | ''>('');
+  const [groupId, setGroupId] = useState('');
+  const [groups, setGroups] = useState<Group[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      const { data, error } = await supabase
+        .from('groups')
+        .select('id, district, age_band, name')
+        .order('district', { ascending: true });
+      if (!error && data) setGroups(data);
+    })();
+  }, []);
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
-    await onAdd({ name, phone: phone || null, source });
+    await onAdd({
+      name,
+      phone: phone || null,
+      source,
+      birth_date: birthDate || null,
+      district: (district as District) || null,
+      group_id: groupId || null,
+    });
     setName('');
     setPhone('');
     setSource('instagram');
+    setBirthDate('');
+    setDistrict('');
+    setGroupId('');
   }
 
   return (
@@ -44,6 +79,39 @@ export default function LeadForm({
             {s.title}
           </option>
         ))}
+      </select>
+      <input
+        type="date"
+        value={birthDate}
+        onChange={(e) => setBirthDate(e.target.value)}
+        className="border p-1"
+        aria-label="Дата рождения"
+      />
+      <select
+        value={district}
+        onChange={(e) => setDistrict((e.target.value as District) || '')}
+        className="border p-1"
+      >
+        <option value="">Район</option>
+        {DISTRICT_OPTIONS.map((d) => (
+          <option key={d} value={d}>
+            {d}
+          </option>
+        ))}
+      </select>
+      <select
+        value={groupId}
+        onChange={(e) => setGroupId(e.target.value)}
+        className="border p-1"
+      >
+        <option value="">Группа</option>
+        {groups
+          .filter((g) => !district || g.district === district)
+          .map((g) => (
+            <option key={g.id} value={g.id}>
+              {g.district} • {g.age_band}
+            </option>
+          ))}
       </select>
       <button
         type="submit"

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -78,7 +78,7 @@ export type Lead = {
   phone: string | null;
   source: LeadSource;
   stage: LeadStage;
-  birth_date: string | null;
-  district: 'Центр' | 'Джикджилли' | 'Махмутлар' | null;
-  group_id: string | null;
+  birth_date?: string | null;
+  district?: 'Центр' | 'Джикджилли' | 'Махмутлар' | null;
+  group_id?: string | null;
 };

--- a/pages/leads.tsx
+++ b/pages/leads.tsx
@@ -5,6 +5,7 @@ import {
   type Lead,
   type LeadStage,
   type LeadSource,
+  type District,
 } from '../lib/types';
 import LeadCard from '../components/LeadCard';
 import LeadModal from '../components/LeadModal';
@@ -22,7 +23,8 @@ function emptyStageMap(): StageMap {
 export default function LeadsPage() {
   const [leads, setLeads] = useState<StageMap>(emptyStageMap());
   const [loading, setLoading] = useState(false);
-  const [openModal, setOpenModal] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [editing, setEditing] = useState<Lead | null>(null);
 
   useEffect(() => {
     loadData();
@@ -30,13 +32,15 @@ export default function LeadsPage() {
 
   async function loadData() {
     setLoading(true);
+    setErrorMsg(null);
     const { data, error } = await supabase
       .from('leads')
-      .select('id, created_at, name, phone, source, stage, birth_date, district, group_id')
+      .select('*')
       .order('created_at', { ascending: false });
 
     if (error) {
       console.error(error);
+      setErrorMsg(error.message);
       setLoading(false);
       return;
     }
@@ -74,18 +78,47 @@ export default function LeadsPage() {
     name,
     phone,
     source,
+    birth_date,
+    district,
+    group_id,
   }: {
     name: string;
     phone: string | null;
     source: LeadSource;
+    birth_date: string | null;
+    district: District | null;
+    group_id: string | null;
   }) {
-    const { error } = await supabase
+    setErrorMsg(null);
+    const { data, error } = await supabase
       .from('leads')
-      .insert({ name, phone, source, stage: 'queue' });
+      .insert({
+        name,
+        phone,
+        source,
+        stage: 'queue',
+        birth_date,
+        district,
+        group_id,
+      })
+      .select('*')
+      .single();
     if (error) {
       console.error(error);
+      setErrorMsg(error.message);
+      await loadData();
       return;
     }
+
+    if (data) {
+      setLeads((prev) => ({
+        ...prev,
+        queue: [data as Lead, ...prev.queue],
+      }));
+      return;
+    }
+
+    // If Supabase didn't return the inserted row, reload the list
     await loadData();
   }
 
@@ -93,22 +126,32 @@ export default function LeadsPage() {
     <div>
       <h1 className="text-2xl font-bold mb-4">Лиды</h1>
       <LeadForm onAdd={addLead} />
+      {errorMsg && <div className="text-red-600 mb-2">{errorMsg}</div>}
       {loading && <div className="text-gray-500">Загрузка…</div>}
       <div className="flex gap-4 overflow-x-auto">
         {LEAD_STAGES.map((stage) => (
-          <div key={stage.key} className="w-64 shrink-0">
+          <div
+            key={stage.key}
+            className="w-64 shrink-0"
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={(e) => {
+              const id = Number(e.dataTransfer.getData('id'));
+              if (!Number.isNaN(id)) changeStage(id, stage.key);
+            }}
+          >
             <h2 className="text-center font-semibold mb-2">{stage.title}</h2>
             {leads[stage.key].map((l) => (
-              <LeadCard key={l.id} lead={l} onStageChange={changeStage} />
+              <LeadCard key={l.id} lead={l} onOpen={(lead) => setEditing(lead)} />
             ))}
           </div>
         ))}
       </div>
-      {openModal && (
+      {editing && (
         <LeadModal
-          onClose={() => setOpenModal(false)}
+          initial={editing}
+          onClose={() => setEditing(null)}
           onSaved={() => {
-            setOpenModal(false);
+            setEditing(null);
             loadData();
           }}
         />


### PR DESCRIPTION
## Summary
- Open detailed lead modal on name click and hide stage selector on mini cards
- Allow dragging lead cards between pipeline stages
- Capture birth date, district, and group when creating a lead

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c170cce62c832ba3e3fccb54c61ead