### PR TITLE
feat: allow viewing client details from group list

### DIFF
--- a/components/GroupWithClients.tsx
+++ b/components/GroupWithClients.tsx
@@ -16,13 +16,14 @@ export default function GroupWithClients({ group, onChanged, districts }: Props)
   const [clients, setClients] = useState<Client[]>([]);
   const [loading, setLoading] = useState(false);
   const [openClient, setOpenClient] = useState(false);
+  const [editingClient, setEditingClient] = useState<Client | null>(null);
 
   async function toggle() {
     if (!open && clients.length === 0) {
       setLoading(true);
       const { data, error } = await supabase
         .from('client_groups')
-        .select('client:clients(id, first_name, last_name)')
+        .select('client:clients(*)')
         .eq('group_id', group.id)
         .returns<{ client: Client }[]>();
       if (!error && data) {
@@ -54,19 +55,37 @@ export default function GroupWithClients({ group, onChanged, districts }: Props)
             <div className="text-sm text-gray-500">Клиентов нет</div>
           )}
           {clients.map((c) => (
-            <div key={c.id} className="text-sm">
+            <button
+              key={c.id}
+              className="text-sm text-blue-600 underline"
+              onClick={() => { setEditingClient(c); setOpenClient(true); }}
+            >
               {c.first_name}
               {c.last_name ? ` ${c.last_name}` : ''}
-            </div>
+            </button>
           ))}
         </div>
       )}
       {openClient && (
         <ClientModal
-          initial={{ district: group.district }}
-          onClose={() => setOpenClient(false)}
-          onSaved={(c) => { if (c) setClients((prev) => [...prev, c]); setOpenClient(false); }}
-          groupId={group.id}
+          initial={editingClient ?? { district: group.district }}
+          onClose={() => { setOpenClient(false); setEditingClient(null); }}
+          onSaved={(c) => {
+            setOpenClient(false);
+            setEditingClient(null);
+            if (c) {
+              setClients((prev) => {
+                const idx = prev.findIndex((p) => p.id === c.id);
+                if (idx >= 0) {
+                  const copy = [...prev];
+                  copy[idx] = c;
+                  return copy;
+                }
+                return [...prev, c];
+              });
+            }
+          }}
+          groupId={editingClient ? undefined : group.id}
           districts={districts}
         />
       )}


### PR DESCRIPTION
## Summary
- make client names clickable in group view to open full details
- load full client data and reuse client modal for editing or viewing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c27f36d774832ba4392a28ba652e73