### PR TITLE
feat: allow viewing client details from group list

### DIFF
--- a/components/ClientModal.tsx
+++ b/components/ClientModal.tsx
@@ -84,66 +84,119 @@ export default function ClientModal({
           {initial ? 'Редактировать клиента' : 'Добавить клиента'}
         </div>
         <div className="grid grid-cols-2 gap-3">
-          <input className="border rounded p-2 col-span-1" placeholder="Имя"
-                 value={form.first_name ?? ''} onChange={e => set('first_name', e.target.value)} />
-          <input className="border rounded p-2 col-span-1" placeholder="Фамилия"
-                 value={form.last_name ?? ''} onChange={e => set('last_name', e.target.value)} />
-          <input className="border rounded p-2 col-span-1" placeholder="Телефон"
-                 value={form.phone ?? ''} onChange={e => set('phone', e.target.value)} />
-          <select className="border rounded p-2 col-span-1" value={form.channel ?? ''} onChange={e => set('channel', e.target.value || null)}>
-            <option value="">Канал</option>
-            <option value="whatsapp">WhatsApp</option>
-            <option value="telegram">Telegram</option>
-            <option value="instagram">Instagram</option>
-          </select>
-          <input
-            type="date"
-            className="border rounded p-2 col-span-1"
-            placeholder="Дата рождения"
-            aria-label="Дата рождения"
-            value={form.birth_date ?? ''}
-            onChange={e => set('birth_date', e.target.value)}
-          />
-          <input
-            className="border rounded p-2 col-span-1"
-            placeholder="Родитель"
-            value={form.parent_name ?? ''}
-            onChange={e => set('parent_name', e.target.value)}
-          />
-          <input
-            type="date"
-            className="border rounded p-2 col-span-1"
-            placeholder="Начало посещения"
-            aria-label="Начало посещения"
-            value={form.start_date ?? ''}
-            onChange={e => set('start_date', e.target.value)}
-          />
-          <select className="border rounded p-2 col-span-1" value={form.gender ?? ''} onChange={e => set('gender', e.target.value || null)}>
-            <option value="">Пол</option>
-            <option value="m">М</option>
-            <option value="f">Ж</option>
-          </select>
-          <select className="border rounded p-2 col-span-1" value={form.payment_status ?? ''} onChange={e => set('payment_status', e.target.value || null)}>
-            <option value="">Статус оплаты</option>
-            <option value="pending">Ожидает</option>
-            <option value="active">Активен</option>
-            <option value="debt">Долг</option>
-          </select>
-          <select className="border rounded p-2 col-span-1" value={form.payment_method ?? ''} onChange={e => set('payment_method', e.target.value || null)}>
-            <option value="">Способ оплаты</option>
-            <option value="cash">Нал</option>
-            <option value="transfer">Перевод</option>
-          </select>
-          <select
-            className="border rounded p-2 col-span-2"
-            value={form.district ?? ''}
-            onChange={e => set('district', e.target.value || null)}
-          >
-            <option value="">Район</option>
-            {districts.map((d) => (
-              <option key={d} value={d}>{d}</option>
-            ))}
-          </select>
+          <label className="col-span-1 flex flex-col gap-1">
+            <span className="text-sm">Имя</span>
+            <input
+              className="border rounded p-2"
+              value={form.first_name ?? ''}
+              onChange={e => set('first_name', e.target.value)}
+            />
+          </label>
+          <label className="col-span-1 flex flex-col gap-1">
+            <span className="text-sm">Фамилия</span>
+            <input
+              className="border rounded p-2"
+              value={form.last_name ?? ''}
+              onChange={e => set('last_name', e.target.value)}
+            />
+          </label>
+          <label className="col-span-1 flex flex-col gap-1">
+            <span className="text-sm">Телефон</span>
+            <input
+              className="border rounded p-2"
+              value={form.phone ?? ''}
+              onChange={e => set('phone', e.target.value)}
+            />
+          </label>
+          <label className="col-span-1 flex flex-col gap-1">
+            <span className="text-sm">Канал</span>
+            <select
+              className="border rounded p-2"
+              value={form.channel ?? ''}
+              onChange={e => set('channel', e.target.value || null)}
+            >
+              <option value="">Не выбрано</option>
+              <option value="whatsapp">WhatsApp</option>
+              <option value="telegram">Telegram</option>
+              <option value="instagram">Instagram</option>
+            </select>
+          </label>
+          <label className="col-span-1 flex flex-col gap-1">
+            <span className="text-sm">Дата рождения</span>
+            <input
+              type="date"
+              className="border rounded p-2"
+              value={form.birth_date ?? ''}
+              onChange={e => set('birth_date', e.target.value)}
+            />
+          </label>
+          <label className="col-span-1 flex flex-col gap-1">
+            <span className="text-sm">Родитель</span>
+            <input
+              className="border rounded p-2"
+              value={form.parent_name ?? ''}
+              onChange={e => set('parent_name', e.target.value)}
+            />
+          </label>
+          <label className="col-span-1 flex flex-col gap-1">
+            <span className="text-sm">Начало посещения</span>
+            <input
+              type="date"
+              className="border rounded p-2"
+              value={form.start_date ?? ''}
+              onChange={e => set('start_date', e.target.value)}
+            />
+          </label>
+          <label className="col-span-1 flex flex-col gap-1">
+            <span className="text-sm">Пол</span>
+            <select
+              className="border rounded p-2"
+              value={form.gender ?? ''}
+              onChange={e => set('gender', e.target.value || null)}
+            >
+              <option value="">Не выбрано</option>
+              <option value="m">М</option>
+              <option value="f">Ж</option>
+            </select>
+          </label>
+          <label className="col-span-1 flex flex-col gap-1">
+            <span className="text-sm">Статус оплаты</span>
+            <select
+              className="border rounded p-2"
+              value={form.payment_status ?? ''}
+              onChange={e => set('payment_status', e.target.value || null)}
+            >
+              <option value="">Не выбрано</option>
+              <option value="pending">Ожидает</option>
+              <option value="active">Активен</option>
+              <option value="debt">Долг</option>
+            </select>
+          </label>
+          <label className="col-span-1 flex flex-col gap-1">
+            <span className="text-sm">Способ оплаты</span>
+            <select
+              className="border rounded p-2"
+              value={form.payment_method ?? ''}
+              onChange={e => set('payment_method', e.target.value || null)}
+            >
+              <option value="">Не выбрано</option>
+              <option value="cash">Нал</option>
+              <option value="transfer">Перевод</option>
+            </select>
+          </label>
+          <label className="col-span-2 flex flex-col gap-1">
+            <span className="text-sm">Район</span>
+            <select
+              className="border rounded p-2"
+              value={form.district ?? ''}
+              onChange={e => set('district', e.target.value || null)}
+            >
+              <option value="">Не выбрано</option>
+              {districts.map((d) => (
+                <option key={d} value={d}>{d}</option>
+              ))}
+            </select>
+          </label>
         </div>
         <div className="flex justify-end gap-2">
           <button className="px-3 py-2 rounded bg-gray-200" onClick={onClose}>Отмена</button>

--- a/components/GroupWithClients.tsx
+++ b/components/GroupWithClients.tsx
@@ -16,13 +16,14 @@ export default function GroupWithClients({ group, onChanged, districts }: Props)
   const [clients, setClients] = useState<Client[]>([]);
   const [loading, setLoading] = useState(false);
   const [openClient, setOpenClient] = useState(false);
+  const [editingClient, setEditingClient] = useState<Client | null>(null);
 
   async function toggle() {
     if (!open && clients.length === 0) {
       setLoading(true);
       const { data, error } = await supabase
         .from('client_groups')
-        .select('client:clients(id, first_name, last_name)')
+        .select('client:clients(*)')
         .eq('group_id', group.id)
         .returns<{ client: Client }[]>();
       if (!error && data) {
@@ -54,19 +55,37 @@ export default function GroupWithClients({ group, onChanged, districts }: Props)
             <div className="text-sm text-gray-500">Клиентов нет</div>
           )}
           {clients.map((c) => (
-            <div key={c.id} className="text-sm">
+            <button
+              key={c.id}
+              className="text-sm text-blue-600 underline"
+              onClick={() => { setEditingClient(c); setOpenClient(true); }}
+            >
               {c.first_name}
               {c.last_name ? ` ${c.last_name}` : ''}
-            </div>
+            </button>
           ))}
         </div>
       )}
       {openClient && (
         <ClientModal
-          initial={{ district: group.district }}
-          onClose={() => setOpenClient(false)}
-          onSaved={(c) => { if (c) setClients((prev) => [...prev, c]); setOpenClient(false); }}
-          groupId={group.id}
+          initial={editingClient ?? { district: group.district }}
+          onClose={() => { setOpenClient(false); setEditingClient(null); }}
+          onSaved={(c) => {
+            setOpenClient(false);
+            setEditingClient(null);
+            if (c) {
+              setClients((prev) => {
+                const idx = prev.findIndex((p) => p.id === c.id);
+                if (idx >= 0) {
+                  const copy = [...prev];
+                  copy[idx] = c;
+                  return copy;
+                }
+                return [...prev, c];
+              });
+            }
+          }}
+          groupId={editingClient ? undefined : group.id}
           districts={districts}
         />
       )}


### PR DESCRIPTION
## Summary
- make client names clickable in group view to open full details
- load full client data and reuse client modal for editing or viewing
- add labels to client form fields for clarity

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c27f36d774832ba4392a28ba652e73