### PR TITLE
Fix task creation

### DIFF
--- a/lib/tasks.ts
+++ b/lib/tasks.ts
@@ -10,7 +10,7 @@ export async function fetchTasks(): Promise<Task[]> {
 export async function createTask(task: Omit<Task, 'id'>): Promise<Task> {
   const { data, error } = await supabase
     .from('tasks')
-    .insert(task)
+    .insert([task])
     .select()
     .single();
   if (error) throw error;

--- a/pages/tasks.tsx
+++ b/pages/tasks.tsx
@@ -72,26 +72,30 @@ export default function TasksPage() {
     if (!title.trim()) {
       return;
     }
-    const task = await createTask({
-      title: title.trim(),
-      completed: false,
-      payment_id: null,
-      is_recurring: isRecurring,
-      due_date: dueDate || null,
-      recurring_interval: isRecurring ? recurringInterval : null,
-      tag,
-      district,
-      client_id: clientId || null,
-    });
-    setTasks((prev) => [...prev, task]);
-    setTitle('');
-    setDueDate('');
-    setRecurringInterval('monthly');
-    setIsRecurring(false);
-    setTag('other');
-    setDistrict('Центр');
-    setClientId('');
-    setShowForm(false);
+    try {
+      const task = await createTask({
+        title: title.trim(),
+        completed: false,
+        payment_id: null,
+        is_recurring: isRecurring,
+        due_date: dueDate || null,
+        recurring_interval: isRecurring ? recurringInterval : null,
+        tag,
+        district,
+        client_id: clientId || null,
+      });
+      setTasks((prev) => [...prev, task]);
+      setTitle('');
+      setDueDate('');
+      setRecurringInterval('monthly');
+      setIsRecurring(false);
+      setTag('other');
+      setDistrict('Центр');
+      setClientId('');
+      setShowForm(false);
+    } catch (e) {
+      alert((e as Error).message);
+    }
   };
 
   const toggle = async (id: string) => {

--- a/supabase/migrations/202505221200_add_completed_to_tasks.sql
+++ b/supabase/migrations/202505221200_add_completed_to_tasks.sql
@@ -1,0 +1,6 @@
+-- Add completed column to tasks table
+alter table public.tasks
+  add column if not exists completed boolean not null default false;
+
+-- Rebuild the PostgREST schema cache so new column is recognized
+notify pgrst, 'reload schema';

--- a/supabase/migrations/202505231200_add_client_id_to_tasks.sql
+++ b/supabase/migrations/202505231200_add_client_id_to_tasks.sql
@@ -1,0 +1,6 @@
+-- Add client_id column to tasks table
+alter table public.tasks
+  add column if not exists client_id uuid references public.clients (id);
+
+-- Refresh the PostgREST schema cache so the new column is recognized
+notify pgrst, 'reload schema';

--- a/supabase/migrations/202505241200_add_district_to_tasks.sql
+++ b/supabase/migrations/202505241200_add_district_to_tasks.sql
@@ -1,0 +1,6 @@
+-- Add district column to tasks table
+alter table public.tasks
+  add column if not exists district text;
+
+-- Refresh the PostgREST schema cache so the new column is recognized
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- ensure Supabase inserts a task row correctly
- surface task creation errors to users
- add missing `completed` column to tasks table
- add missing `client_id` column to tasks table
- add missing `district` column to tasks table

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c27f0929b0832ba08ee35273000be8