### PR TITLE
Track attendance by district schedule

### DIFF
--- a/lib/districts.ts
+++ b/lib/districts.ts
@@ -1,2 +1,9 @@
 export const DISTRICT_OPTIONS = ['Центр', 'Джикджилли', 'Махмутлар'] as const;
 export type District = (typeof DISTRICT_OPTIONS)[number];
+
+// Days of week for trainings per district: 0 = Sunday ... 6 = Saturday
+export const DISTRICT_TRAINING_DAYS: Record<District, number[]> = {
+  Центр: [2, 4], // Tuesday, Thursday
+  Джикджилли: [3, 6], // Wednesday, Saturday
+  Махмутлар: [1, 5], // Monday, Friday
+};

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -17,7 +17,6 @@ export type Client = {
 };
 
 export type AttendanceRecord = {
-  id: string;
   client_id: string;
   date: string;
   present: boolean;

--- a/pages/attendance.tsx
+++ b/pages/attendance.tsx
@@ -1,72 +1,105 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, Fragment } from 'react';
 import { supabase } from '../lib/supabaseClient';
 import { Client, AttendanceRecord } from '../lib/types';
+import {
+  DISTRICT_OPTIONS,
+  DISTRICT_TRAINING_DAYS,
+  District,
+} from '../lib/districts';
 
 type Group = {
   id: string;
   age_band: string;
-  schedule?: string | null;
 };
 
 type GroupData = Group & { clients: Client[] };
 
-const DISTRICTS = ['Центр', 'Джикджилли', 'Махмутлар'];
+function getTrainingDates(district: District, month: string): string[] {
+  const [yearStr, monthStr] = month.split('-');
+  const year = Number(yearStr);
+  const monthIndex = Number(monthStr) - 1; // 0-based
+  const daysInMonth = new Date(year, monthIndex + 1, 0).getDate();
+  const weekdays = DISTRICT_TRAINING_DAYS[district] || [];
+  const dates: string[] = [];
+  for (let day = 1; day <= daysInMonth; day++) {
+    const d = new Date(year, monthIndex, day);
+    if (weekdays.includes(d.getDay())) {
+      dates.push(d.toISOString().slice(0, 10));
+    }
+  }
+  return dates;
+}
 
 export default function AttendancePage() {
-  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10));
+  const [month, setMonth] = useState(() => new Date().toISOString().slice(0, 7));
   const [records, setRecords] = useState<Record<string, boolean>>({});
   const [openDistricts, setOpenDistricts] = useState<Record<string, boolean>>({});
   const [groups, setGroups] = useState<Record<string, GroupData[]>>({});
   const [loading, setLoading] = useState<Record<string, boolean>>({});
-
   useEffect(() => {
-    (async () => {
-      const { data, error } = await supabase
-        .from('attendance')
-        .select('client_id, present')
-        .eq('date', date);
-      if (!error && data) {
-        const map: Record<string, boolean> = {};
-        (data as AttendanceRecord[]).forEach((r) => {
-          map[r.client_id] = r.present;
-        });
-        setRecords(map);
-      } else {
-        setRecords({});
-      }
-    })();
-  }, [date]);
+    setRecords({});
+    setGroups({});
+    Object.keys(openDistricts).forEach((d) => {
+      if (openDistricts[d]) loadDistrict(d);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [month]);
 
-  async function toggle(clientId: string) {
-    const present = !records[clientId];
-    setRecords((prev) => ({ ...prev, [clientId]: present }));
+  async function toggle(clientId: string, day: string) {
+    const key = `${clientId}-${day}`;
+    const present = !records[key];
+    setRecords((prev) => ({ ...prev, [key]: present }));
     const { error } = await supabase
       .from('attendance')
-      .upsert({ client_id: clientId, date, present }, { onConflict: 'client_id,date' });
+      .upsert({ client_id: clientId, date: day, present }, { onConflict: 'client_id,date' });
     if (error) alert(error.message);
   }
 
   async function loadDistrict(district: string) {
     setLoading((p) => ({ ...p, [district]: true }));
-    const { data, error } = await supabase
+    const { data: groupData, error } = await supabase
       .from('groups')
-      .select(
-        'id, age_band, schedule, client_groups(client:clients(id, first_name, last_name))'
-      )
+      .select('id, age_band')
       .eq('district', district)
       .order('age_band', { ascending: true })
-      .order('schedule', { ascending: true })
-      .returns<(Group & { client_groups: { client: Client }[] })[]>();
+      .returns<Group[]>();
 
-    if (!error && data) {
-      const result: GroupData[] = data.map((g) => ({
-        id: g.id,
-        age_band: g.age_band,
-        schedule: g.schedule,
-        clients: (g.client_groups || []).map((cg) => cg.client),
+    if (!error && groupData) {
+      const ids = groupData.map((g) => g.id);
+      const { data: clientData } = await supabase
+        .from('client_groups')
+        .select('group_id, client:clients(id, first_name, last_name)')
+        .in('group_id', ids.length ? ids : ['-'])
+        .returns<{ group_id: string; client: Client }[]>();
+
+      const clientMap: Record<string, Client[]> = {};
+      (clientData || []).forEach((cg) => {
+        if (!clientMap[cg.group_id]) clientMap[cg.group_id] = [];
+        clientMap[cg.group_id].push(cg.client);
+      });
+
+      const result: GroupData[] = groupData.map((g) => ({
+        ...g,
+        clients: clientMap[g.id] || [],
       }));
       setGroups((p) => ({ ...p, [district]: result }));
+
+      const clientIds = result.flatMap((g) => g.clients.map((c) => c.id));
+      const dates = getTrainingDates(district as District, month);
+      if (clientIds.length && dates.length) {
+        const { data: attendanceData } = await supabase
+          .from('attendance')
+          .select('client_id, date, present')
+          .in('client_id', clientIds)
+          .in('date', dates)
+          .returns<AttendanceRecord[]>();
+        const map: Record<string, boolean> = {};
+        (attendanceData || []).forEach((r) => {
+          map[`${r.client_id}-${r.date}`] = r.present;
+        });
+        setRecords((prev) => ({ ...prev, ...map }));
+      }
     } else {
       setGroups((p) => ({ ...p, [district]: [] }));
     }
@@ -86,57 +119,91 @@ export default function AttendancePage() {
       <h1 className="text-2xl font-bold mb-4">Журнал посещений</h1>
       <div className="mb-4">
         <input
-          type="date"
-          value={date}
-          onChange={(e) => setDate(e.target.value)}
+          type="month"
+          value={month}
+          onChange={(e) => setMonth(e.target.value)}
           className="border rounded px-3 py-2"
         />
       </div>
       <div className="space-y-4">
-        {DISTRICTS.map((d) => (
-          <div key={d} className="border rounded-xl bg-white/70 shadow">
-            <button
-              className="w-full text-left px-4 py-2 font-semibold"
-              onClick={() => toggleDistrict(d)}
-            >
-              {d}
-            </button>
-            {openDistricts[d] && (
-              <div className="p-4 space-y-4">
-                {loading[d] && (
-                  <div className="text-sm text-gray-500">загрузка…</div>
-                )}
-                {!loading[d] &&
-                  (groups[d] || []).map((g) => (
-                    <div key={g.id} className="space-y-2">
-                      <div className="font-semibold">
-                        {g.age_band}
-                        {g.schedule ? ` • ${g.schedule}` : ''}
-                      </div>
-                      <div className="pl-4 space-y-1">
-                        {g.clients.map((c) => (
-                          <label key={c.id} className="flex items-center gap-2">
-                            <input
-                              type="checkbox"
-                              checked={!!records[c.id]}
-                              onChange={() => toggle(c.id)}
-                            />
-                            <span>
-                              {c.first_name}
-                              {c.last_name ? ` ${c.last_name}` : ''}
-                            </span>
-                          </label>
+        {DISTRICT_OPTIONS.map((d) => {
+          const dates = getTrainingDates(d, month);
+          return (
+            <div key={d} className="border rounded-xl bg-white/70 shadow">
+              <button
+                className="w-full text-left px-4 py-2 font-semibold"
+                onClick={() => toggleDistrict(d)}
+              >
+                {d}
+              </button>
+              {openDistricts[d] && (
+                <div className="p-4 overflow-x-auto">
+                  {loading[d] && (
+                    <div className="text-sm text-gray-500">загрузка…</div>
+                  )}
+                  {!loading[d] && (
+                    <table className="min-w-full text-sm">
+                      <thead>
+                        <tr>
+                          <th className="px-2 py-1 text-left">ФИО</th>
+                          {dates.map((dt) => (
+                            <th key={dt} className="px-2 py-1 text-center">
+                              {new Date(dt).getDate()}
+                            </th>
+                          ))}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {(groups[d] || []).map((g) => (
+                          <Fragment key={g.id}>
+                            <tr>
+                              <td
+                                colSpan={dates.length + 1}
+                                className="font-semibold pt-2"
+                              >
+                                {g.age_band}
+                              </td>
+                            </tr>
+                            {g.clients.map((c) => (
+                              <tr key={c.id} className="border-t">
+                                <td className="px-2 py-1">
+                                  {c.first_name}
+                                  {c.last_name ? ` ${c.last_name}` : ''}
+                                </td>
+                                {dates.map((dt) => {
+                                  const key = `${c.id}-${dt}`;
+                                  return (
+                                    <td key={dt} className="px-2 py-1 text-center">
+                                      <input
+                                        type="checkbox"
+                                        checked={!!records[key]}
+                                        onChange={() => toggle(c.id, dt)}
+                                      />
+                                    </td>
+                                  );
+                                })}
+                              </tr>
+                            ))}
+                            {g.clients.length === 0 && (
+                              <tr>
+                                <td
+                                  className="px-2 py-1 text-sm text-gray-500"
+                                  colSpan={dates.length + 1}
+                                >
+                                  Клиентов нет
+                                </td>
+                              </tr>
+                            )}
+                          </Fragment>
                         ))}
-                        {g.clients.length === 0 && (
-                          <div className="text-sm text-gray-500">Клиентов нет</div>
-                        )}
-                      </div>
-                    </div>
-                  ))}
-              </div>
-            )}
-          </div>
-        ))}
+                      </tbody>
+                    </table>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/supabase/migrations/202505301200_create_attendance_table.sql
+++ b/supabase/migrations/202505301200_create_attendance_table.sql
@@ -1,0 +1,30 @@
+-- Create attendance table for tracking daily presence per client
+create table if not exists public.attendance (
+  client_id uuid references public.clients (id) on delete cascade,
+  date date not null,
+  present boolean not null default false,
+  primary key (client_id, date)
+);
+
+-- Enable RLS and allow public CRUD operations
+alter table public.attendance enable row level security;
+
+create policy "Public read attendance" on public.attendance
+for select
+using (true);
+
+create policy "Public upsert attendance" on public.attendance
+for insert
+with check (true);
+
+create policy "Public update attendance" on public.attendance
+for update
+using (true)
+with check (true);
+
+create policy "Public delete attendance" on public.attendance
+for delete
+using (true);
+
+-- Refresh PostgREST schema cache so new table/columns are recognized
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- Map weekly training days for each district
- Let admins pick a month and show only that month's training dates
- Record attendance per client and date with schedule-based checklists
- Show daily columns once per district, grouping each age band beneath a shared header
- Create `attendance` table with a `date` column and public RLS policies to persist checkbox state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c27edd85b4832b8892e0507a68f81c